### PR TITLE
ユーザー登録・更新のエラー時にモーダルを表示するようにした

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -49,9 +49,8 @@ def user_create():
     data = request.json
     query = User.query.filter(User.anyNumber == data.get('anyNumber'))
     if db.session.query(query.exists()).scalar():
-        return jsonify({"result": "error", "message": "その値は既に存在します。存在しない値を入力してください。"}), 500
-    # if data.get('anyNumber') is None or data.get('name') is None or data.get('password') is None:
-    #     return jsonify({"result": "error", "message": "必須項目に空欄があります。値を入力してください。"})
+        return jsonify({"data": "data", "result": "error", "message": "入力した任意番号は既に存在します。存在しない値を入力してください。"}), 500
+    # 入力欄に値を入力後、値を削除すると空欄が入ってしまうので後で修正する。
     newUser = User(
         anyNumber=data.get('anyNumber'),
         name=data.get('name'),
@@ -81,9 +80,8 @@ def user_update(id):
     data = request.json
     query = User.query.filter(User.anyNumber == data.get('anyNumber'))
     if db.session.query(query.exists()).scalar() and query.anyNumber != data.get('anyNumber'):
-        return jsonify({"result": "error", "message": "その値は既に存在します。存在しない値を入力してください。"}), 500
-    # if data.get('anyNumber') is '' or data.get('name') is '' or data.get('password') is '':
-    #     return jsonify({"result": "error", "message": "必須項目に空欄があります。値を入力してください。"})
+        return jsonify({"result": "error", "message": "入力した任意番号は既に存在します。存在しない値を入力してください。"}), 500
+    # 入力欄に値を入力後、値を削除すると空欄が入ってしまうので後で修正する。
     user = User.query.filter(User.id == id).one()
 
     user.anyNumber = data.get('anyNumber')

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -222,7 +222,7 @@
 
             <!-- 保存モーダル -->
             <div>
-                <select-modal modal-name='upsertModal' modal-message='保存しますか？'
+                <select-modal-static modal-name='upsertModal' modal-message='保存しますか？'
                     @selected="upsertModalProcess($event);" />
             </div>
 
@@ -231,6 +231,10 @@
                 <select-modal modal-name='deleteModal' modal-message='削除しますか？'
                     @selected="deleteModalProcess($event);" />
             </div>
+
+            <!-- エラーモーダル -->
+            <confirm-modal-danger :title="title" :message="message">
+            </confirm-modal-danger>
 
         </div>
 
@@ -243,6 +247,8 @@
                 data: {
                     users: [],               //全件user
                     user: [],                //選択中のuser
+                    title: '',
+                    message: '',
                 },
                 methods: {
                     // ---Items---
@@ -269,10 +275,15 @@
                                 Vue.set(self.user, 'id', response.data.id)
                                 self.getUsers();
                                 self.user.isInsert = false;
+                                app.$router.push({ query: { page: 'index' } });
                             })
-                            .catch(function (response) {
-                                console.log('エラー');
-                                console.log(response);
+                            .catch(function (error) {
+                                app.title = 'エラー';
+                                app.message = error.response.data.message;
+                                if (error.response.data.message === undefined)  //応急処置。後でちゃんとエラーハンドリングする。
+                                    app.message = '必須項目に空欄があります。値を入力してください。';
+                                app.$bvModal.show('confirmModalDanger');
+                                console.log(error);
                             });
                     },
                     updateUser: async function (item) {
@@ -281,10 +292,15 @@
                             .then(function (response) {
                                 self.getUsers();
                                 console.log(response);
+                                app.$router.push({ query: { page: 'index' } });
                             })
-                            .catch(function (response) {
-                                console.log('エラー');
-                                console.log(response);
+                            .catch(function (error) {
+                                app.title = 'エラー';
+                                app.message = error.response.data.message;
+                                if (error.response.data.message === undefined)  //応急処置。後でちゃんとエラーハンドリングする。
+                                    app.message = '必須項目に空欄があります。値を入力してください。';
+                                app.$bvModal.show('confirmModalDanger');
+                                console.log(error);
                             });
                     },
                     deleteUser: async function (item) {


### PR DESCRIPTION
関連Issue：ユーザー登録には任意番号を振る #745

関連プルリク：ユーザーに任意番号カラム追加。エラーハンドリング。 #901
の続き。
エラー時にモーダルで警告を出すようにした。