### PR TITLE
請求・見積作成・更新時に得意先を選択しないと保存できないようにした。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -605,7 +605,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="primary" @click="bulkUpsert(invoice);showConfirmModal();">保存
+                        <b-button pill variant="primary" @click="bulkUpsert(invoice);">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(invoice,'copyModal');" v-b-tooltip.hover.top="'複製'"><i
@@ -633,6 +633,9 @@
 
             <!-- 確認モーダル -->
             <confirm-modal :title="title" :message="message"></confirm-modal>
+
+            <!-- エラーモーダル -->
+            <confirm-modal-danger :title="title" :message="message"></confirm-modal-danger>
 
             <!-- コピーモーダル -->
             <div>
@@ -722,11 +725,19 @@
                             });
                     },
                     bulkUpsert: async function (item) {
+                        if (!item.customerId) {
+                            this.title = 'エラー';
+                            this.message = '得意先を選択してください。';
+                            this.$bvModal.show('confirmModalDanger');
+                            return
+                        }
                         if (!item.id) {
                             await this.insertInvoice(item);
+                            this.$bvModal.show('confirmModal');
                         }
                         else {
                             await this.updateInvoice(item);
+                            this.$bvModal.show('confirmModal');
                         }
                     },
                     insertInvoice: async function (item) {
@@ -925,9 +936,6 @@
                         console.log(this.invoice);
                         this.$bvModal.show(modalName);
                     },
-                    showConfirmModal: function () {
-                        this.$bvModal.show('confirmModal');
-                    },
                     deleteModalProcess(result) {
                         this.$bvModal.hide('deleteModal');
                         if (result === true) {
@@ -1105,8 +1113,10 @@
                             this.getInvoices();
                             this.countChanged = 0;
                         }
-                        this.clearFileList();
-                        router.push({ path: "?page=index" });
+                        if (!isUpdate || (isUpdate && this.invoice.customerId)) {
+                            this.clearFileList();
+                            router.push({ path: "?page=index" });
+                        }
                     },
                     openViewer: function (f) {
                         //this.modal.setFooterContent(f.filename);

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -217,10 +217,11 @@
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="顧客名"
                                         label-for="customer" class="customer" label-align="right">
-                                        <b-form-input v-model="invoice.customerName" id="customerName" size="sm"
-                                            autocomplete="off" @dblclick="$bvModal.show('customer-modal')"
-                                            v-on:keydown.enter="onKeyDownCustomer">
-                                        </b-form-input>
+                                        <b-container class="text-left" style="padding: 0;">
+                                            <b-button @click="$bvModal.show('customer-modal')" size="sm"
+                                                variant="primary">検索</b-button>
+                                            {{invoice.customerName}}
+                                        </b-container>
                                         <!-- 得意先一覧モーダル -->
                                         <b-modal size="xl" id="customer-modal">
                                             <p>顧客を選択してください</p>
@@ -951,11 +952,6 @@
                         Vue.set(self.invoice, 'customerName', record.customerName);
                         Vue.set(self.invoice, 'honorificTitle', record.honorificTitle);
                         this.$bvModal.hide("customer-modal");
-                    },
-                    // 顧客名入力→Enter
-                    onKeyDownCustomer(record) {
-                        console.log(record);
-                        Vue.set(self.invoice, 'customerId', null);
                     },
                     // 商品名モーダル選択時
                     itemSelect(record) {

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -635,7 +635,7 @@
                         <b-button @click="checkChange" v-b-tooltip.hover.top="'戻る'">＜</b-button>
                     </b-col>
                     <b-col class="text-right" md="auto" cols="auto">
-                        <b-button pill variant="primary" @click="bulkUpsert(quotation);showConfirmModal();">保存
+                        <b-button pill variant="primary" @click="bulkUpsert(quotation);">保存
                         </b-button>
                         <b-button v-if="pageName==='show'" pill size="lg" id="copy-button"
                             @click="modalShow(quotation,'copyModal');" v-b-tooltip.hover.top="'複製'"><i
@@ -656,6 +656,9 @@
 
             <!-- 確認モーダル -->
             <confirm-modal :title="title" :message="message"></confirm-modal>
+
+            <!-- エラーモーダル -->
+            <confirm-modal-danger :title="title" :message="message"></confirm-modal-danger>
 
             <!-- コピーモーダル -->
             <div>
@@ -740,11 +743,19 @@
                             });
                     },
                     bulkUpsert: async function (item) {
+                        if (!item.customerId) {
+                            this.title = 'エラー';
+                            this.message = '得意先を選択してください。';
+                            this.$bvModal.show('confirmModalDanger');
+                            return
+                        }
                         if (!item.id) {
                             await this.insertQuotation(item);
+                            this.$bvModal.show('confirmModal');
                         }
                         else {
                             await this.updateQuotation(item);
+                            this.$bvModal.show('confirmModal');
                         }
                     },
                     insertQuotation: async function (item) {
@@ -946,9 +957,6 @@
                         console.log(this.quotation);
                         this.$bvModal.show(modalName);
                     },
-                    showConfirmModal: function () {
-                        this.$bvModal.show('confirmModal');
-                    },
                     deleteModalProcess(result) {
                         this.$bvModal.hide('deleteModal');
                         if (result === true) {
@@ -1058,7 +1066,9 @@
                             this.getQuotations();
                             this.countChanged = 0;
                         }
-                        router.push({ path: "?page=index" });
+                        if (!isUpdate || (isUpdate && this.quotation.customerId)) {
+                            router.push({ path: "?page=index" });
+                        }
                     },
                     pdfout: async function () {
                         self = this;

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -229,10 +229,11 @@
                                 <b-col xl>
                                     <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="顧客名"
                                         label-for="customer" class="customer" label-align="right">
-                                        <b-form-input v-model="quotation.customerName" id="customerName" size="sm"
-                                            @dblclick="$bvModal.show('customer-modal')"
-                                            v-on:keydown.enter="onKeyDownCustomer">
-                                        </b-form-input>
+                                        <b-container class="text-left" style="padding: 0;">
+                                            <b-button @click="$bvModal.show('customer-modal')" size="sm"
+                                                variant="primary">検索</b-button>
+                                            {{quotation.customerName}}
+                                        </b-container>
                                         <!-- 得意先一覧モーダル -->
                                         <b-modal size="xl" id="customer-modal">
                                             <p>顧客を選択してください</p>
@@ -972,11 +973,6 @@
                         Vue.set(self.quotation, 'customerName', record.customerName);
                         Vue.set(self.quotation, 'honorificTitle', record.honorificTitle);
                         this.$bvModal.hide("customer-modal");
-                    },
-                    // 顧客名入力→Enter
-                    onKeyDownCustomer(record) {
-                        console.log(record);
-                        Vue.set(self.quotation, 'customerId', null);
                     },
                     // 商品名モーダル選択時
                     itemSelect(record) {


### PR DESCRIPTION
関連Issue：請求・見積書の顧客名自由入力の廃止 #926

- 請求・見積書作成・更新時の得意先選択モーダルはボタン押下で呼ぶようにした。
- 請求・見積書作成・更新時に得意先を選択しないと保存できない仕組みにした。