### PR TITLE
請求・見積書の新規更新画面。顧客名と検索ボタンの間にスペースを設けた。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -216,7 +216,7 @@
                                         label-for="customer" class="customer" label-align="right">
                                         <b-container class="text-left" style="padding: 0;">
                                             <b-button @click="$bvModal.show('customer-modal')" size="sm"
-                                                variant="primary">検索</b-button>
+                                                variant="primary" class="mr-3">検索</b-button>
                                             {{invoice.customerName}}
                                         </b-container>
                                         <!-- 得意先一覧モーダル -->

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -229,7 +229,7 @@
                                         label-for="customer" class="customer" label-align="right">
                                         <b-container class="text-left" style="padding: 0;">
                                             <b-button @click="$bvModal.show('customer-modal')" size="sm"
-                                                variant="primary">検索</b-button>
+                                                variant="primary" class="mr-3">検索</b-button>
                                             {{quotation.customerName}}
                                         </b-container>
                                         <!-- 得意先一覧モーダル -->
@@ -943,7 +943,7 @@
                                 console.log(response);
                                 self.countedFiles = response.data;
                             });
-                    },                    
+                    },
                     modalShow: function (item, modalName) {
                         this.quotation = item;
                         console.log(this.quotation);


### PR DESCRIPTION
関連Issue：請求・見積の顧客名選択ボタンと顧客名の間は空ける #953