### PR TITLE
各種一覧ページのヘッダーに共通コンポーネント使用

### DIFF
--- a/app/static/component/menu-header.js
+++ b/app/static/component/menu-header.js
@@ -8,7 +8,7 @@ Vue.component('menu-header', {
                     <b-row>
                         <b-col>
                             <router-link to="?page=store">
-                                <b-button pill variant="success" class="mr-3" @click="InvoiceAddRow();">＋新規作成
+                                <b-button pill variant="success" class="mr-3" @click="mainAddRow();">＋新規作成
                                 </b-button>
                             </router-link>
                         </b-col>
@@ -23,7 +23,7 @@ Vue.component('menu-header', {
     </div>
     `,
     props: {
-        InvoiceAddRow: Function,
+        mainAddRow: Function,
     },
     methods: {
         modeName: function () {

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -32,30 +32,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="CategoryAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <b-button pill href="/item-page">商品画面へ
-                                    </b-button>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="CategoryAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -25,25 +25,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="CustomerAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="CustomerAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -53,6 +53,7 @@
     <script src="static/component/sc-menu.js"></script>
     <script src="static/component/select-modal.js"></script>
     <script src="static/component/confirm-modal.js"></script>
+    <script src="static/component/menu-header.js"></script>
 
     <style>
         [v-cloak] {

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -10,7 +10,6 @@
 
         <!-- コンポーネント -->
         <script src="../static/component/list-invoice.js"></script>
-        <script src="../static/component/menu-header.js"></script>
 
         <style>
             .card-header {
@@ -111,7 +110,7 @@
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
                 <!-- ヘッダー -->
-                <menu-header :Invoice-add-row="InvoiceAddRow"></menu-header>
+                <menu-header :main-add-row="InvoiceAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -78,25 +78,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="ItemAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="ItemAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -453,7 +436,7 @@
                     routeFrom: '',
                     title: '',              //モーダルタイトル
                     message: '',            //モーダルメッセージ
-                    countedFiles:{}
+                    countedFiles: {}
                 },
                 methods: {
                     // ---Items---

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -31,30 +31,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="MakerAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <b-button pill href="/item-page">商品画面へ
-                                    </b-button>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="MakerAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -13,25 +13,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="MemoAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="MemoAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -113,25 +113,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="QuotationAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <b-col class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="QuotationAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -943,7 +926,7 @@
                                 console.log(response);
                                 self.countedFiles = response.data;
                             });
-                    },                    
+                    },
                     modalShow: function (item, modalName) {
                         this.quotation = item;
                         console.log(this.quotation);

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -32,26 +32,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="UnitAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="UnitAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -32,26 +32,8 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                    <router-link to="?page=store">
-                                        <b-button pill variant="success" class="mr-3" @click="UserAddRow();">＋新規作成
-                                        </b-button>
-                                    </router-link>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <!-- ヘッダー -->
+                <menu-header :main-add-row="UserAddRow"></menu-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>


### PR DESCRIPTION
関連Issue：一覧画面のヘッダーは全てコンポーネントを使用できそう #963

新規作成ボタンとサイドメニュー用ハンバーガーメニューで構成された一覧ページ用ヘッダーに共通コンポーネントを使用。