### PR TITLE
サイドメニューのチェックボタン。アイコンと文字の間のスペースを半分にした。

### DIFF
--- a/app/static/component/sc-menu.js
+++ b/app/static/component/sc-menu.js
@@ -16,7 +16,7 @@ Vue.component('sc-menu', {
                     </b-nav>
                     <b-nav vertical>
                         <b-button variant="primary" block href="/check-page">
-                        <b-icon icon="check"></b-icon>　チェック
+                        <b-icon icon="check"></b-icon> チェック
                         </b-button>
                         <b-button variant="primary" block href="/customer-page"><i
                                 class="fas fa-building"></i>　得意先

--- a/app/templates/mw_menu.html
+++ b/app/templates/mw_menu.html
@@ -2,7 +2,7 @@
     <% block content %>
         <div id="app" class="text-center">
             <b-button class="mt-2" variant="primary" id="check" style="width: 80%;">
-                <b-icon icon="check"></b-icon>　チェック
+                <b-icon icon="check"></b-icon> チェック
             </b-button>
             <b-button class="mt-1" variant="primary" id="customer" style="width: 80%;">
                 <i class="fas fa-building"></i>　得意先


### PR DESCRIPTION
関連Issue：サイドメニューのチェックページへのリンクボタン。アイコンと文字の間のスペースは半角にする。 #966