### PR TITLE
入金モーダルの作成。請求＿入金CRUD作成。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -874,6 +874,9 @@ def invoice_payment_update(id):
                 del(item['createdAt'])
             if 'updatedAt' in item:
                 del(item['updatedAt'])
+            if item.get('paymentDate'):
+                item['paymentDate'] = datetime.strptime(
+                    item.get('paymentDate'), "%Y-%m-%d")
 
             if item.get('id'):
                 index = next((i for i, x in enumerate(

--- a/app/api.py
+++ b/app/api.py
@@ -862,13 +862,17 @@ def invoice_payment_create():
 def invoice_payment_update(id):
     data = request.json
     invoice = Invoice.query.filter(Invoice.id == id).one()
+    invoicePaymentIds = db.session.query(Invoice_Payment.id).filter(
+        Invoice_Payment.invoiceId == id).all()
     if not invoice:
         return jsonify({"result": "No Data", "id": id, "data": data})
 
     if data.get('invoice_payments'):
         update_list = []
         insert_list = []
-        delete_in_list = invoice.invoice_payments
+        delete_in_list = []
+        for i in invoicePaymentIds:
+            delete_in_list.append(i.id)
         for item in data['invoice_payments']:
             if 'createdAt' in item:
                 del(item['createdAt'])
@@ -879,11 +883,11 @@ def invoice_payment_update(id):
                     item.get('paymentDate'), "%Y-%m-%d")
 
             if item.get('id'):
+                update_list.append(item)
                 index = next((i for i, x in enumerate(
-                    delete_in_list) if x.id == item['id']), None)
+                    delete_in_list) if x == item['id']), None)
                 if index != None:
                     delete_in_list.pop(index)
-                    update_list.append(item)
             else:
                 insert_list.append(item)
 

--- a/app/api.py
+++ b/app/api.py
@@ -869,11 +869,6 @@ def invoice_payment_update(id):
         update_list = []
         insert_list = []
         delete_in_list = invoice.invoice_payments
-        print('hogehoge:')
-        print(delete_in_list)
-        for x in invoice.invoice_payments:
-            print('DB')
-            print(x.id)
         for item in data['invoice_payments']:
             if 'createdAt' in item:
                 del(item['createdAt'])
@@ -881,24 +876,14 @@ def invoice_payment_update(id):
                 del(item['updatedAt'])
 
             if item.get('id'):
-                print('--idあり--')
-                print(next((i for i, x in enumerate(
-                    invoice.invoice_payments) if x.id == item['id']), None))
-                if next((i for i, x in enumerate(invoice.invoice_payments) if x.id == item['id']), None) != None:
-                    delete_in_list.remove(x)
-                    print('deletelist')
-                    print(delete_in_list)
-                    update_list.append(x)
+                index = next((i for i, x in enumerate(
+                    delete_in_list) if x.id == item['id']), None)
+                if index != None:
+                    delete_in_list.pop(index)
+                    update_list.append(item)
             else:
-                print('--idあり--')
                 insert_list.append(item)
 
-        print('update')
-        print(update_list)
-        print('insert')
-        print(insert_list)
-        print('delete')
-        print(delete_in_list)
         db.session.bulk_update_mappings(Invoice_Payment, update_list)
         db.session.bulk_insert_mappings(Invoice_Payment, insert_list)
         db.session.query(Invoice_Payment).filter(Invoice_Payment.id.in_(

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -423,7 +423,10 @@
 
                         <b-row class="mb-3">
                             <b-col cols="auto">
-                                <b-button variant="primary" @click="modalShow(invoice,'payment-modal');">入金処理</b-button>
+                                <!-- 請求書発行前に請求書＿入金テーブルにINSERTするとFKが迷子になるので -->
+                                <b-button v-if="invoice.id" variant="primary"
+                                    @click="modalShow(invoice,'payment-modal');">入金処理</b-button>
+                                <b-button v-else variant="primary" disabled>入金処理</b-button>
                                 <!-- <b-form-checkbox class="mr-3" v-model="invoice.isPaid">入金済み</b-form-checkbox> -->
                             </b-col>
                             <!-- <b-col>
@@ -650,6 +653,11 @@
                             <b-button pill variant="primary" @click="addRowInvoicePayment();">✙</b-button>
                         </b-col>
                     </b-row>
+                    <template #modal-footer>
+                        <button v-b-modal.modal-close_visit class="btn btn-secondary m-1">Cancel</button>
+                        <button v-b-modal.modal-close_visit class="btn btn-primary m-1"
+                            @click="console.log('save!');">Save</button>
+                    </template>
                 </b-modal>
             </div>
         </div>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -104,6 +104,11 @@
                 padding: 0.25rem 1.25rem;
                 border-bottom: 1px solid #CED4DA;
             }
+
+            #payment-delete:hover {
+                border-color: #ed254e;
+                background-color: #ed254e;
+            }
         </style>
 
         <div id="app" v-cloak>
@@ -412,13 +417,14 @@
 
                         <b-row class="mb-3">
                             <b-col cols="auto">
-                                <b-form-checkbox class="mr-3" v-model="invoice.isPaid">入金済み</b-form-checkbox>
+                                <b-button variant="primary" @click="modalShow(invoice,'payment-modal');">入金処理</b-button>
+                                <!-- <b-form-checkbox class="mr-3" v-model="invoice.isPaid">入金済み</b-form-checkbox> -->
                             </b-col>
-                            <b-col>
+                            <!-- <b-col>
                                 <b-form-input v-model="invoice.paymentDate" id="paymentDate" size="sm" type="date"
                                     style="width: 150px;">
                                 </b-form-input>
-                            </b-col>
+                            </b-col> -->
                         </b-row>
 
                         <b-row>
@@ -597,6 +603,48 @@
             <div>
                 <select-modal modal-name='deleteModal' modal-message='削除しますか？'
                     @selected="deleteModalProcess($event);" />
+            </div>
+
+            <!-- 入金モーダル -->
+            <div>
+                <b-modal size="xl" id="payment-modal" :title="'請求書No. ' + invoice.applyNumber">
+                    <b-table hover striped small sort-by="ID" id="payment-table" :items="invoice.invoice_payments"
+                        label="Table Options" :fields="[
+                              {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
+                              {  key: 'paymentDate', label: '入金日' },
+                              {  key: 'paymentMethod', label: '支払い方法' },
+                              {  key: 'paymentAmount', label: '入金金額' },
+                              {  key: 'remarks', label: '備考' },
+                              {  key: 'delete', thClass: 'd-none' },
+                        ]">
+                        <template v-slot:cell(paymentDate)="data">
+                            <b-form-input v-model="data.item.paymentDate" type="date" size="sm" autocomplete="off">
+                            </b-form-input>
+                        </template>
+                        <template v-slot:cell(paymentMethod)="data">
+                            <b-form-select v-model="data.item.paymentMethod" :options="['口座振込','現金','クレジット']" size="sm"
+                                autocomplete="off">
+                            </b-form-select>
+                        </template>
+                        <template v-slot:cell(paymentAmount)="data">
+                            <b-form-input v-model="data.item.paymentAmount" type="number" size="sm" autocomplete="off">
+                            </b-form-input>
+                        </template>
+                        <template v-slot:cell(remarks)="data">
+                            <b-form-input v-model="data.item.remarks" size="sm" autocomplete="off">
+                            </b-form-input>
+                        </template>
+                        <template v-slot:cell(delete)="data">
+                            <b-button pill id="payment-delete" size="sm" @click="deleteRowInvoicePayment(data.item)">－
+                            </b-button>
+                        </template>
+                    </b-table>
+                    <b-row class="d-flex justify-content-end" id="item_add">
+                        <b-col cols="16" md="auto">
+                            <b-button pill variant="primary" @click="addRowInvoicePayment();">✙</b-button>
+                        </b-col>
+                    </b-row>
+                </b-modal>
             </div>
         </div>
 
@@ -791,6 +839,19 @@
                         this.invoice.invoice_items.push({
                             invoiceId: this.invoice.id
                         })
+                    },
+                    addRowInvoicePayment: function () {
+                        if (this.invoice.length === 0) {
+                            alert('請求書を選択してください');
+                            return;
+                        }
+                        this.invoice.invoice_payments.push({
+                            invoiceId: this.invoice.id
+                        })
+                    },
+                    deleteRowInvoicePayment: function (data) {
+                        console.log(data);
+                        // TODO:ここで削除処理
                     },
                     insertQuotation: async function (item) {
                         self = this;

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -656,7 +656,7 @@
                     <template #modal-footer>
                         <button v-b-modal.modal-close_visit class="btn btn-secondary m-1">Cancel</button>
                         <button v-b-modal.modal-close_visit class="btn btn-primary m-1"
-                            @click="console.log('save!');">Save</button>
+                            @click="upsertInvoicePayments(invoice)">Save</button>
                     </template>
                 </b-modal>
             </div>
@@ -776,6 +776,13 @@
                         self.countChanged = 0;
                         app.title = '更新';
                         app.message = '保存しました。';
+                    },
+                    upsertInvoicePayments: async function (item) {
+                        self = this;
+                        await axios.put("/invoice_payment/" + item.id, item)
+                            .then(function (response) {
+                                console.log(response);
+                            });
                     },
                     copyInvoice: async function (item) {
                         let invoiceResource = JSON.stringify(item);

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -783,6 +783,8 @@
                             .then(function (response) {
                                 console.log(response);
                             });
+                        await self.getInvoice(self.invoice);
+                        localStorage.setItem('invoice', JSON.stringify(self.invoice));
                     },
                     copyInvoice: async function (item) {
                         let invoiceResource = JSON.stringify(item);


### PR DESCRIPTION
関連Issue：入金処理の実装 #952

- 請求書発行後でないと「入金処理」ボタンが押せないようにした。
- 入金モーダルの作成。
- 入金履歴のCRUD機能。API作成。（Saveボタン押下時に請求＿入金モデルのみ適用）
- 入金履歴削除ボタン作成

入金保存時の確認モーダル等は後で実装する。