### PR TITLE
入金履歴削除バグ修正

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -901,6 +901,10 @@ def invoice_payment_update(id):
         db.session.query(Invoice_Payment).filter(Invoice_Payment.id.in_(
             delete_in_list)).delete(synchronize_session='fetch')
 
+    else:
+        db.session.query(Invoice_Payment).filter(
+            Invoice_Payment.invoiceId == id).delete()
+
     # 入金合計額が上回れば入金済みに
     if invoice.isPaid == False and paymentSum >= priceIncludingTax:
         invoice.isPaid = True


### PR DESCRIPTION
プルリク：入金処理機能完成。 #1002

で追加した入金処理にバグがあったので修正。
フロント側ので表示されているinvoice.invoice_paymentsを－ボタンで削除→履歴レコードが０件の状態で保存すると、invoice.invoice_paymentsが巻き戻るバグを修正した。