### PR TITLE
未入金チェック一覧機能の完成。

### DIFF
--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -167,12 +167,13 @@ Vue.component('invoice-list', {
 Vue.component('invoice-list-payment', {
     template: `
     <div>
-        <b-table responsive hover small id="invoicetable" sort-by="ID" small label="Table Options"
+        <b-table responsive hover small id="invoicetable" label="Table Options"
             :items=invoicesIndicateIndex :fields="[
         {  key: 'update', label: '' },
         {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
         {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
         {  key: 'applyDate', label: '日付', thClass: 'text-center', tdClass: 'text-center' },
+        {  key: 'customerAnyNumber', label: '任意番号', thClass: 'text-center', tdClass: 'text-center', },
         {  key: 'customerName', label: '得意先名', thClass: 'text-center', },
         {  key: 'title', label: '件名', thClass: 'text-center', },
         {  key: 'unpaidAmount', label: '未入金額', thClass: 'text-center', tdClass: 'text-right' },

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -145,6 +145,7 @@
                                 <invoice-list v-if="procName=='normal'" :select-invoice="selectInvoice"
                                     :invoices-indicate-index="invoicesIndicateIndex" :counted-files="countedFiles">
                                 </invoice-list>
+                                <!-- 未入金 -->
                                 <invoice-list-payment v-else :select-invoice="selectInvoice"
                                     :invoices-indicate-index="invoicesIndicateIndex" :counted-files="countedFiles">
                                     </invoice-list>
@@ -1274,6 +1275,12 @@
                         });
                         this.invoicesIndicateCount = invoices.length;
                         this.invoicesIndicateAmount = amount;
+                        // コンポーネント内でソート出来ないのでここでソート。通常の請求書一覧画面には任意番号表示が無いので、混乱防止の為に未入金一覧のみ
+                        if (this.procName === 'payment') {
+                            invoices.sort(function (a, b) {
+                                return a.customerAnyNumber - b.customerAnyNumber;
+                            });
+                        }
                         return invoices;
                     },
                     // 得意先選択モーダルの検索機能

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -683,7 +683,7 @@
             script.type = 'text/javascript';
             const files = ['def-pdf.js'];
             for (file of files) {
-                script.src = "static/component/customize/"+file;
+                script.src = "static/component/customize/" + file;
                 var firstScript = document.getElementsByTagName('script')[0];
                 firstScript.parentNode.insertBefore(script, firstScript);
             }
@@ -1007,6 +1007,7 @@
                         Vue.set(self.invoice, 'customerId', record.id);
                         Vue.set(self.invoice, 'customerName', record.customerName);
                         Vue.set(self.invoice, 'honorificTitle', record.honorificTitle);
+                        this.invoice.customerAnyNumber = record.anyNumber;
                         this.$bvModal.hide("customer-modal");
                     },
                     // 商品名モーダル選択時


### PR DESCRIPTION
関連Issue：未入金チェックの実装（一覧） #950

- 得意先選択時に請求へ得意先任意番号を自動挿入するようにした
- 未入金チェック一覧ヘッダーに得意先任意番号追加。
- 未入金チェック一覧ページではデフォルトで得意先任意番号でソートするようにした。