### PR TITLE
請求一覧に日付フィルター追加。バグ修正。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -867,8 +867,8 @@ def invoice_payment_create():
 def invoice_payment_update(id):
     data = request.json
     req = request.args
-    priceIncludingTax = req.get('priceIncludingTax')
-    paymentSum = req.get('paymentSum')
+    priceIncludingTax = int(req.get('priceIncludingTax'))
+    paymentSum = int(req.get('paymentSum'))
     invoice = Invoice.query.filter(Invoice.id == id).one()
     invoicePaymentIds = db.session.query(Invoice_Payment.id).filter(
         Invoice_Payment.invoiceId == id).all()

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -134,10 +134,10 @@
                                     <b-col sm>
                                     </b-col>
                                     <b-col sm>
-                                        <is-show v-if="procName=='normal'" @emit-show-all="updateIsInvoicesShowAll">
-                                        </is-show>
-                                        <day-search v-else @emit-day-start="updateDayStart"
-                                            @emit-day-end="updateDayEnd"></day-search>
+                                        <!-- <is-show v-if="procName=='normal'" @emit-show-all="updateIsInvoicesShowAll">
+                                        </is-show> -->
+                                        <day-search @emit-day-start="updateDayStart" @emit-day-end="updateDayEnd">
+                                        </day-search>
                                     </b-col>
                                 </b-row>
                                 <indicate-count :indicate-count="invoicesIndicateCount"></indicate-count>
@@ -1161,9 +1161,6 @@
                     updateInvoices(invoices) {
                         this.invoices = invoices;
                     },
-                    updateIsInvoicesShowAll(isShow) {
-                        this.isInvoicesShowAll = isShow;
-                    },
                     updateDayStart(start) {
                         this.searchDayStart = start;
                     },
@@ -1185,6 +1182,9 @@
                     if (this.pageName == 'show') {
                         //this.getFileList(self.invoice.applyNumber);
                         this.getFileListDZ();
+                    }
+                    if (this.procName == 'normal') {
+                        this.isInvoicesShowAll = true;
                     }
                     this.modal = new tingle.modal({
                         footer: false,
@@ -1213,7 +1213,7 @@
                         return this.$route.query.page;
                     },
                     headerName() {
-                        if (this.procName == "normal") return "請求書入力";
+                        if (this.procName == "normal") return "請求書一覧";
                         else return "未入金一覧";
                     },
                     procName() {


### PR DESCRIPTION
関連Issue：未入金・請求書一覧ページの修正まとめ #1018

- 請求書一覧ページの表示・非表示フィルターを日付フィルターに変更。
- 請求書一覧は全件表示。未入金一覧は未入金の請求書もののみ表示するように変更
- 完済が完了した請求書が未入金一覧に表示されてしまうバグ修正（API修正）