### PR TITLE
請求書・見積書＿商品に備考欄追加

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -388,9 +388,10 @@
 
                             <template #row-details="data">
                                 <b-row>
-                                    <b-col>
+                                    <div style="width: 55px;"></div>
+                                    <b-col cols="3">
                                         <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="原価単価:"
-                                            label-for="cost">
+                                            label-for="cost" label-align="right">
                                             <b-form-input v-model="data.item.cost" id="cost" size="sm" type="number">
                                             </b-form-input>
                                         </b-form-group>
@@ -403,6 +404,13 @@
                                     </b-col>
                                     <b-col>
                                         <p class="mt-1">粗利金額: {{profit(data)}}</p>
+                                    </b-col>
+                                    <b-col cols="4">
+                                        <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="備考:"
+                                            label-for="remarks" label-align="right">
+                                            <b-form-input v-model="data.item.remarks" id="remarks" size="sm">
+                                            </b-form-input>
+                                        </b-form-group>
                                     </b-col>
                                 </b-row>
                             </template>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -282,6 +282,9 @@
                                     <b-col>
                                         <p class="mt-1">粗利金額: {{profit(data)}}</p>
                                     </b-col>
+                                    <b-col>
+                                        <p class="mt-1">備考: {{data.item.remarks}}</p>
+                                    </b-col>
                                 </b-row>
                             </template>
 

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -451,9 +451,10 @@
 
                             <template #row-details="data">
                                 <b-row>
-                                    <b-col cols>
+                                    <div style="width: 55px;"></div>
+                                    <b-col cols="3">
                                         <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="原価単価:"
-                                            label-for="cost">
+                                            label-for="cost" label-align="right">
                                             <b-form-input v-model="data.item.cost" id="cost" size="sm" type="number">
                                             </b-form-input>
                                         </b-form-group>
@@ -466,6 +467,13 @@
                                     </b-col>
                                     <b-col>
                                         <p class="mt-1">粗利金額: {{profit(data)}}</p>
+                                    </b-col>
+                                    <b-col cols="4">
+                                        <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="備考:"
+                                            label-for="remarks" label-align="right">
+                                            <b-form-input v-model="data.item.remarks" id="remarks" size="sm">
+                                            </b-form-input>
+                                        </b-form-group>
                                     </b-col>
                                 </b-row>
                             </template>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -280,6 +280,9 @@
                                     <b-col>
                                         <p class="mt-1">粗利金額: {{profit(data)}}</p>
                                     </b-col>
+                                    <b-col>
+                                        <p class="mt-1">備考: {{data.item.remarks}}</p>
+                                    </b-col>
                                 </b-row>
                             </template>
 


### PR DESCRIPTION
関連Issue：請求書・見積書明細のレイアウト変更。備考欄の追加。 #987

ついでに削除済み請求・見積書＿商品にも備考欄追加。