### PR TITLE
見積一覧ヘッダーに任意番号追加。ソート周りの修正。

### DIFF
--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -155,12 +155,14 @@
                             <b-row align-h="end">
                                 <p class="mr-3">表示件数 {{ quotationsIndicateCount }}件</p>
                             </b-row>
-                            <b-table responsive hover small id="quotationtable" sort-by="ID" small label="Table Options"
-                                :items=quotationsIndicateIndex :fields="[
+                            <b-table responsive hover small id="quotationtable" label="Table Options"
+                                :items=quotationsIndicateIndex :sort-by.sync="this.sortByQuotations"
+                                :sort-desc.sync="this.sortDesc" :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'applyNumber', label: '見積番号', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'applyDate', label: '日付', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'customerAnyNumber', label: 'No.', thClass: 'text-center', tdClass: 'text-center', sortable: true },
                           {  key: 'customerName', label: '得意先名', thClass: 'text-center', },
                           {  key: 'title', label: '件名', thClass: 'text-center', },
                           {  key: 'totalAmount', label: '見積金額', thClass: 'text-center', tdClass: 'text-right' },
@@ -687,6 +689,8 @@
             var app = new Vue({
                 el: '#app',
                 data: {
+                    sortByQuotations: 'id',
+                    sortDesc: true,
                     searchQuotationWord: '',        //請求書検索
                     quotationsShowValue: 'notConverted',    //請求書検索
                     quotationsIndicateCount: 0,     //請求書検索

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -976,6 +976,7 @@
                         Vue.set(self.quotation, 'customerId', record.id);
                         Vue.set(self.quotation, 'customerName', record.customerName);
                         Vue.set(self.quotation, 'honorificTitle', record.honorificTitle);
+                        this.quotation.customerAnyNumber = record.anyNumber;
                         this.$bvModal.hide("customer-modal");
                     },
                     // 商品名モーダル選択時


### PR DESCRIPTION
関連Issue：見積一覧にも任意番号カラム追加。一覧表示時にソート追加。 #1024

- 見積書の新規・更新画面で得意先を選択すると、得意先任意番号が自動挿入されるように修正。
- 見積一覧ヘッダーに得意先任意番号カラム追加。
- 見積一覧読み込み時にidの降順でソートするようにした。
- 得意先任意番号でソート可能にした。