### PR TITLE
得意先のデフォルトのソートを任意番号に変更

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -346,7 +346,7 @@
             var app = new Vue({
                 el: '#app',
                 data: {
-                    sortByCustomers: 'customerKana',
+                    sortByCustomers: 'anyNumber',
                     searchCustomerWord: '',     //得意先検索
                     customersShowValue: '',     //得意先検索
                     customersIndicateCount: 0,  //得意先検索


### PR DESCRIPTION
関連Issue：得意先一覧のデフォルトのソートは任意番号順に変更 #1034

すぐに変更してほしいとの事なので、mainにmerge先を向ける。