### PR TITLE
セッションタイムアウト後にログアウトするとNotFoundエラーになるバグの解消

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -91,7 +91,7 @@ def logout():
     logout_user()
     # flash("ログアウトしました")
 
-    return redirect('/')
+    return redirect('/login')
 
 # ------　ユーザー認証ここまで -------
 
@@ -153,6 +153,7 @@ def homePage():
 
 
 @app.route('/check-page')
+@login_required
 def checkPage():
     return render_template('check.html')
 
@@ -182,6 +183,7 @@ def itemPage():
 
 
 @app.route('/memo-page')
+@login_required
 def memoPage():
     return render_template('memo.html')
 

--- a/app/main.py
+++ b/app/main.py
@@ -80,15 +80,18 @@ def login_post():
 
 @app.route('/logout', methods=['GET'])
 def logout():
-    # セッションタイムアウト後にcurrent_user.idを参照するとエラーになるので一旦コメントアウト
-    # newHistory = History(
-    #     userName=current_user.id,
-    #     modelName='',
-    #     modelId='',
-    #     action='logout'
-    # )
-    # db.session.add(newHistory)
-    # db.session.commit()
+    try:
+        newHistory = History(
+            userName=current_user.id,
+            modelName='',
+            modelId='',
+            action='logout'
+        )
+        db.session.add(newHistory)
+        db.session.commit()
+    except AttributeError as e:
+        print(e)
+        pass
     logout_user()
     # flash("ログアウトしました")
 

--- a/app/main.py
+++ b/app/main.py
@@ -80,18 +80,19 @@ def login_post():
 
 @app.route('/logout', methods=['GET'])
 def logout():
-    newHistory = History(
-        userName=current_user.id,
-        modelName='',
-        modelId='',
-        action='logout'
-    )
-    db.session.add(newHistory)
-    db.session.commit()
+    # セッションタイムアウト後にcurrent_user.idを参照するとエラーになるので一旦コメントアウト
+    # newHistory = History(
+    #     userName=current_user.id,
+    #     modelName='',
+    #     modelId='',
+    #     action='logout'
+    # )
+    # db.session.add(newHistory)
+    # db.session.commit()
     logout_user()
     # flash("ログアウトしました")
 
-    return redirect('/login')
+    return redirect('/')
 
 # ------　ユーザー認証ここまで -------
 


### PR DESCRIPTION
関連Issue：ログアウトをするとページが見つかりませんとなってしまう #1043

- セッションタイムアウト後にcurrent_userを参照しているのでNotFoundになっている可能性が高いので、current_userを参照しないようにした。
- ついでに@login_requiredを入れ忘れているページに@login_requiredを入れた。