### PR TITLE
CSVデータドロップゾーンのレイアウト崩れ修正

### DIFF
--- a/app/templates/csv_upload.html
+++ b/app/templates/csv_upload.html
@@ -140,7 +140,7 @@
             })
 
             Dropzone.options.myDropzone = { // camelized version of the `id`
-                dictDefaultMessage: 'ここにファイルをドロップ',
+                dictDefaultMessage: '+',
                 autoProcessQueue: false,
                 maxFiles: 1,
                 addRemoveLinks: true,


### PR DESCRIPTION
CSVアップロードページのドロップゾーンのdescriptionがレイアウト崩れを起こしていたので、それを修正。