### PR TITLE
CSVインポートのモデル名エラー解消。Invoice_PaymentをCSVインポートに対応。

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -395,6 +395,9 @@ def CsvUpload():
     except (exc.IntegrityError, sqlite3.IntegrityError) as e:
         print(e)
         return jsonify({"result": "error", "message": "UNIQUEが重複しています。重複しない値を指定してください。", "e_message": str(e)}), 500
+    except exc.CompileError as e:
+        print(e)
+        return jsonify({"result": "error", "message": "存在しないカラムがあります。対象となるテーブルとCSVのカラムを確認してください。", "e_message": str(e)}), 500
     except ValueError as e:
         print(e)
         return jsonify({"result": "error", "message": "不正な値があります。CSVに規格外または不要な空欄が無いか確認してください。", "e_message": str(e)}), 500
@@ -420,7 +423,7 @@ def upsert_csv():
     dirList.remove('.gitkeep')
 
     for file_name in dirList:
-        class_name = file_name.replace(".csv", "").capitalize()
+        class_name = file_name.replace(".csv", "")
         model_class = getattr(models, class_name)
         with open(fixtures_dir + '/' + file_name, encoding='utf-8') as csv_file:
             reader = csv.reader(csv_file, delimiter=',')

--- a/app/templates/csv_upload.html
+++ b/app/templates/csv_upload.html
@@ -107,7 +107,7 @@
                     selected: null,
                     target: [
                         { value: null, text: '選択してください' }, { value: "User", text: 'ユーザー' }, { value: "Customer", text: '得意先' }, { value: "Item", text: '商品' },
-                        { value: "Invoice", text: '請求書' }, { value: "Invoice_Item", text: '請求書商品' }, { value: "Quotation", text: '見積書' }, { value: "Quotation_Item", text: '見積書商品' },
+                        { value: "Invoice", text: '請求書' }, { value: "Invoice_Item", text: '請求書商品' }, { value: "Invoice_Payment", text: '請求書入金' }, { value: "Quotation", text: '見積書' }, { value: "Quotation_Item", text: '見積書商品' },
                         { value: "Memo", text: 'メモ' }, { value: "Unit", text: '単位' }, { value: "Category", text: 'カテゴリー' }, { value: "Maker", text: 'メーカー' },
                     ],
                     message: '',


### PR DESCRIPTION
関連Issue：CSVアップロード機能のエラーハンドリング強化。 #1038

- CSV保存時のファイル命名の際に、アッパーケースで命名されていなかったので、アッパーケースになるように修正。（ファイル名からモデルを取得する必要があるため）
- Invoice_PaymentがCSVアップロード機能に対応していなかったので対応。