### PR TITLE
ログイン・ログアウト履歴取得クエリに取得件数制限をかけた。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -4,7 +4,7 @@ from models import *
 from flask import jsonify, request
 import json
 from datetime import date
-from sqlalchemy import or_, and_, extract
+from sqlalchemy import desc, or_, and_, extract
 from flask_login import current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -1764,7 +1764,8 @@ def history_index():
 @app.route('/login-histories', methods=['GET'])
 def login_history_index():
     loginHistories = History.query.filter(or_(
-        History.action == 'login', History.action == 'logout'))
+        History.action == 'login', History.action == 'logout')).order_by(desc(History.id))
+    loginHistories.limit(_LIMIT_NUM)
     return jsonify(HistorySchema(many=True).dump(loginHistories))
 
 

--- a/app/api.py
+++ b/app/api.py
@@ -1764,8 +1764,7 @@ def history_index():
 @app.route('/login-histories', methods=['GET'])
 def login_history_index():
     loginHistories = History.query.filter(or_(
-        History.action == 'login', History.action == 'logout')).order_by(desc(History.id))
-    loginHistories.limit(_LIMIT_NUM)
+        History.action == 'login', History.action == 'logout')).order_by(desc(History.id)).limit(_LIMIT_NUM)
     return jsonify(HistorySchema(many=True).dump(loginHistories))
 
 

--- a/app/templates/csv_upload.html
+++ b/app/templates/csv_upload.html
@@ -108,7 +108,7 @@
                     target: [
                         { value: null, text: '選択してください' }, { value: "User", text: 'ユーザー' }, { value: "Customer", text: '得意先' }, { value: "Item", text: '商品' },
                         { value: "Invoice", text: '請求書' }, { value: "Invoice_Item", text: '請求書商品' }, { value: "Invoice_Payment", text: '請求書入金' }, { value: "Quotation", text: '見積書' }, { value: "Quotation_Item", text: '見積書商品' },
-                        { value: "Memo", text: 'メモ' }, { value: "Unit", text: '単位' }, { value: "Category", text: 'カテゴリー' }, { value: "Maker", text: 'メーカー' },
+                        { value: "Memo", text: 'メモ' }, { value: "Unit", text: '単位' }, { value: "Category", text: 'カテゴリー' }, { value: "Maker", text: 'メーカー' }, { value: "History", text: '操作履歴' },
                     ],
                     message: '',
                     title: '',


### PR DESCRIPTION
関連Issue：ログイン履歴取得APIに制限をかけた方が良さそう。 #1066

- ログイン・ログアウト取得クエリにlimitで100指定
- ログイン・ログアウト取得クエリにorder_sort(desc)をかけて最新順にした。
- デバッグ用にcsvインポート機能に操作履歴追加。