### PR TITLE
実績ページ。バック：年間請求書取得。フロント：迷走。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install marshmallow-sqlalchemy
 RUN pip install Flask-Migrate 
 RUN pip install Pillow 
 RUN pip install flask-login
+RUN pip install python-dateutil
 
 # Setup initial Database
 #RUN rm -r migrations

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -40,6 +40,19 @@
             <b-col cols="11">
               <b-card border-variant="white" class="mb-3 text-center" header="月別売上推移表" header-border-variant="light">
                 <b-row>
+                  <b-col>
+                    <b-form-input v-model="year" id="year" size="sm" placeholder="年">
+                    </b-form-input>
+                  </b-col>
+                  <b-col>
+                    <b-form-input v-model="month" id="month" size="sm" placeholder="期首">
+                    </b-form-input>
+                  </b-col>
+                  <b-col>
+                    <b-button variant="primary" size="sm" @click="getInvoices(null,null,year,month);">検索</b-button>
+                  </b-col>
+                </b-row>
+                <b-row>
                   <p class="mr-3"> ○○○○年度 ○○月～○○月 </p>
                 </b-row>
                 <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options"
@@ -69,9 +82,12 @@
         router,
         data: {
           invoices: [],
+          currentTerms: [{ "month": 1 }, { "month": 2 }, { "month": 3 }, { "month": 4 }, { "month": 5 }, { "month": 6 }, { "month": 7 }, { "month": 8 }, { "month": 9 }, { "month": 10 }, { "month": 11 }, { "month": 12 },],
+          year: null,
+          month: null,
         },
         methods: {
-          getInvoices: async function (searchWord = '', offset = 0) {
+          getInvoices: async function (searchWord = '', offset = 0, year = null, month = null) {
             self = this;
             url = '/v1/invoices'
             await axios.get(url, {
@@ -80,6 +96,8 @@
                 offset: offset,
                 // 全件取得
                 limit: 0,
+                year: year,
+                month: month,
               }
             })
               .then(function (response) {
@@ -87,6 +105,14 @@
                 self.invoices = response.data;
               });
           },
+          monthTotals() {
+            for (let i = 0; i < 12; i++) {
+              let currentTerm = (Number(this.month) + i);
+              let index = ((currentTerm) <= 12) ? currentTerm : currentTerm - 12;
+            }
+            const a = this.currentTerms.findIndex(element => element.month == 3);
+            console.log(a);
+          }
         },
         mounted: function () {
           document.querySelector('title').textContent = '請求実績';


### PR DESCRIPTION
関連Issue：グラフページの作成 #1104

- back:年間の請求書を取得できるようにした。
   - (例)2022年5月(期首)を選択すると、2022年5月1日～2023年4月31日まで取得できる。
- front:back側で取得してきた請求書を月ごとにオブジェクトで別けようとしているがうまくいっていない。現状処理回数が爆増する未来しか見えない。

フロント側の処理がほぼ確実に悪手になりつつある。バック側で月ごとの請求合計等は振り分けてしまった方が良いだろうか？