### PR TITLE
実績ページ。１年間の請求書を取得する処理のみに留める。ルーティング別けたバージョン。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install marshmallow-sqlalchemy
 RUN pip install Flask-Migrate 
 RUN pip install Pillow 
 RUN pip install flask-login
+RUN pip install python-dateutil
 
 # Setup initial Database
 #RUN rm -r migrations

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -40,10 +40,23 @@
             <b-col cols="11">
               <b-card border-variant="white" class="mb-3 text-center" header="月別売上推移表" header-border-variant="light">
                 <b-row>
+                  <b-col>
+                    <b-form-input v-model="year" id="year" size="sm" placeholder="年">
+                    </b-form-input>
+                  </b-col>
+                  <b-col>
+                    <b-form-input v-model="month" id="month" size="sm" placeholder="期首">
+                    </b-form-input>
+                  </b-col>
+                  <b-col>
+                    <b-button variant="primary" size="sm" @click="getAchievement(year,month);">検索</b-button>
+                  </b-col>
+                </b-row>
+                <b-row>
                   <p class="mr-3"> ○○○○年度 ○○月～○○月 </p>
                 </b-row>
                 <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options"
-                  :items=invoices :fields="[
+                  :items=achievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: '', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
@@ -68,23 +81,23 @@
         el: '#app',
         router,
         data: {
-          invoices: [],
+          achievements: [],
+          year: null,
+          month: null,
         },
         methods: {
-          getInvoices: async function (searchWord = '', offset = 0) {
+          getAchievement: async function (year = null, month = null) {
             self = this;
-            url = '/v1/invoices'
+            url = '/v1/achievements'
             await axios.get(url, {
               params: {
-                search: searchWord,
-                offset: offset,
-                // 全件取得
-                limit: 0,
+                year: year,
+                month: month,
               }
             })
               .then(function (response) {
                 console.log(response);
-                self.invoices = response.data;
+                self.achievements = response.data;
               });
           },
         },


### PR DESCRIPTION
実績ページ。１年間の請求書を取得する処理のみに留める。 #1113
のAPIルーディングを別けたバージョン。
Pandasを使う場合、データの構造が若干違ってくる気がしたので、一応このバージョンもプルリクを出しておく。