### PR TITLE
実績データ集計API作成のため、ルーティングを別けた。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -439,8 +439,6 @@ def invoice_index_v1():
     # テスト的に300に
     limit = int(req.get('limit')) if req.get('limit') else 300
     offset = int(req.get('offset')) if req.get('offset') else 0
-    # reqMonth = int(req.get('month')) if req.get('month') else None
-    # reqYear = int(req.get('year')) if req.get('year') else None
     # 各種フィルタリング処理
     if searchWord:
         if len(searchWord) == 4:

--- a/app/api.py
+++ b/app/api.py
@@ -439,8 +439,8 @@ def invoice_index_v1():
     # テスト的に300に
     limit = int(req.get('limit')) if req.get('limit') else 300
     offset = int(req.get('offset')) if req.get('offset') else 0
-    reqMonth = int(req.get('month')) if req.get('month') else None
-    reqYear = int(req.get('year')) if req.get('year') else None
+    # reqMonth = int(req.get('month')) if req.get('month') else None
+    # reqYear = int(req.get('year')) if req.get('year') else None
     # 各種フィルタリング処理
     if searchWord:
         if len(searchWord) == 4:
@@ -462,7 +462,32 @@ def invoice_index_v1():
         else:
             invoices = Invoice.query.filter(
                 and_(Invoice.isDelete == False, or_(Invoice.customerName.like('%'+searchWord+'%'), Invoice.customerAnyNumber == searchWord)))
-         
+
+    else:
+        invoices = Invoice.query.filter(Invoice.isDelete == False)
+    if offset:
+        invoices = invoices.offset(offset)
+    if limit:
+        invoices = invoices.limit(limit)
+
+    newHistory = History(
+        userName=current_user.id,
+        modelName='Invoice',
+        modelId=None,
+        action='gets'
+    )
+    db.session.add(newHistory)
+    db.session.commit()
+    return jsonify(InvoiceSchema(many=True).dump(invoices))
+
+
+@app.route('/v1/achievements', methods=['GET'])
+@app.route('/achievements', methods=['GET'])
+def invoice_achievement_v1():
+    # パラメータを準備
+    req = request.args
+    reqMonth = int(req.get('month')) if req.get('month') else None
+    reqYear = int(req.get('year')) if req.get('year') else None
 
     if reqYear and reqMonth:
         beforeDate = date(reqYear, reqMonth, 1)
@@ -471,14 +496,8 @@ def invoice_index_v1():
                 years=1)-relativedelta.relativedelta(days=1)
         invoices = Invoice.query.filter(and_(
             Invoice.isDelete == False, Invoice.applyDate.between(beforeDate, afterDate)))
-
-
     else:
         invoices = Invoice.query.filter(Invoice.isDelete == False)
-    if offset:
-        invoices = invoices.offset(offset)
-    if limit:
-        invoices = invoices.limit(limit)
 
     newHistory = History(
         userName=current_user.id,

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -104,7 +104,11 @@
         },
         mounted: function () {
           document.querySelector('title').textContent = '請求実績';
-          this.getAchievements();
+          // 今月を含めた１年分のデータ取得のため
+          let today = new Date();
+          this.year = today.getFullYear() - 1;
+          this.month = today.getMonth() + 2;
+          this.getAchievements(this.year, this.month);
         },
         computed: {
           pageName() {

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -50,14 +50,14 @@
                     </b-form-input>
                   </b-col>
                   <b-col>
-                    <b-button variant="primary" size="sm" @click="getInvoices(null,null,year,month);">検索</b-button>
+                    <b-button variant="primary" size="sm" @click="getAchievements(year,month);">検索</b-button>
                   </b-col>
                 </b-row>
                 <b-row>
                   <p class="mr-3"> ○○○○年度 ○○月～○○月 </p>
                 </b-row>
                 <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options"
-                  :items=invoices :fields="[
+                  :items=achievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: '', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
@@ -82,33 +82,29 @@
         el: '#app',
         router,
         data: {
-          invoices: [],
+          achievements: [],
           year: null,
           month: null,
         },
         methods: {
-          getInvoices: async function (searchWord = '', offset = 0, year = null, month = null) {
+          getAchievements: async function (year = null, month = null) {
             self = this;
-            url = '/v1/invoices'
+            url = '/v1/achievements'
             await axios.get(url, {
               params: {
-                search: searchWord,
-                offset: offset,
-                // 全件取得
-                limit: 0,
                 year: year,
                 month: month,
               }
             })
               .then(function (response) {
                 console.log(response);
-                self.invoices = response.data;
+                self.achievements = response.data;
               });
           },
         },
         mounted: function () {
           document.querySelector('title').textContent = '請求実績';
-          this.getInvoices();
+          this.getAchievements();
         },
         computed: {
           pageName() {


### PR DESCRIPTION
関連Issue：グラフページの作成 #1104

- 実績データ集計API作成のため、ルーティングを別けた。
- 実績ページ読み込み時に今月を含めた過去１年分のデータを取得するようにした。