### PR TITLE
月間実績API。請求合計と粗利合計を出力できるようにした。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -509,7 +509,7 @@ def invoice_achievement_v1():
 
 
 # 実績データに使用
-def multiply(price=0, count=0):
+def multiply(price, count):
     return price*count
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -431,6 +431,5 @@ class SettingSchema(ma.SQLAlchemyAutoSchema):
 
 # 独自定義
 class AchievementSchema(Schema):
-    applyDate = fields.Date()
-    applyNumber = fields.Int()
-    total_tax = fields.Int()
+    applyDate = fields.Str()
+    monthlySales = fields.Int()

--- a/app/models.py
+++ b/app/models.py
@@ -433,3 +433,4 @@ class SettingSchema(ma.SQLAlchemyAutoSchema):
 class AchievementSchema(Schema):
     applyDate = fields.Str()
     monthlySales = fields.Int()
+    monthlyProfit = fields.Int()

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -59,9 +59,8 @@
                 <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options"
                   :items=achievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
-                          {  key: '', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: '', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'applyDate', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'monthlySales', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: '', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: '', label: '粗利率', thClass: 'text-center', tdClass: 'text-center' },
                         ]">

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -61,7 +61,7 @@
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'applyDate', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'monthlySales', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: '', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'monthlyProfit', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: '', label: '粗利率', thClass: 'text-center', tdClass: 'text-center' },
                         ]">
                 </b-table>


### PR DESCRIPTION
関連Issue：グラフページの作成 #1104

- 請求書_商品保存時に原価が保存されないバグ修正
- 実績API。請求合計と粗利合計をグループ化してSUM。