### PR TITLE
実績ページにグラフを適用

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -517,7 +517,7 @@ def multiply(price, count, isTax, tax):
     isTax_ = bool(isTax)
     if isTax_ == True:
         # 単純な数値は認識されない？
-        return price*count*(1+tax/100)
+        return price*count*(1+tax/100.0)
     else:
         return price*count
 

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -39,6 +39,7 @@
           <b-row class="mt-1">
             <b-col></b-col>
             <b-col cols="11">
+              <div id="achievement-chart"></div>
               <b-card border-variant="white" class="mb-3 text-center" header="月別売上推移表" header-border-variant="light">
                 <b-row>
                   <b-col>
@@ -103,6 +104,11 @@
               .then(function (response) {
                 console.log(response);
                 self.achievements = response.data;
+                df = new dfd.DataFrame(self.achievements,)
+                df.print();
+                df.setIndex({ index: df['applyDate'].values, inplace: true })
+                df.drop({ columns: ['applyDate'], inplace: true })
+                df.plot("achievement-chart").bar({ columns: ["monthlyProfit", "monthlySales"] })
                 // 原価率計算
                 // let achievements = self.achievements;
                 // achievements.map(achieve => {


### PR DESCRIPTION
関連Issue：グラフページの作成 #1104

- /achievementsのレスポンス項目のmonthlySalesに税率計算が適用されないバグ修正。（内税・外税の分岐修正は未完了）
- 実績ページに棒グラフを適用してみる。