### PR TITLE
実績ページ表示が遅いので、chart.jsのCDNを削除

### DIFF
--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -1,8 +1,7 @@
 <% extends "head.html" %>
   <% block content %>
 
-    <!-- chart.js -->
-    <script src="../static//library/chart.js"></script>
+    <!-- danfo.js -->
     <script src="https://cdn.jsdelivr.net/npm/danfojs@1.1.0/lib/bundle.min.js"></script>
 
     <style>


### PR DESCRIPTION
関連Issue：テスト的に作成した実績ページ（グラフページ）が重いので対応。