### PR TITLE
実績ページの内税・外税を含めた請求合計金額計算ができない問題を解消した

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -508,22 +508,21 @@ def invoice_achievement_v1():
     return jsonify(InvoiceSchema(many=True).dump(invoices))
 
 
-# 実績データに使用(粗利率のみフロントでの計算)
-# def multiply(price, count):
-#     return price*count
+def multiply(price, count, tax):
+    # 単純な数値は認識されない？
+    return price*count*(1+tax/100.0)
 
 
-def multiply(price, count, isTax, tax):
-    isTax_ = bool(isTax)
-    if isTax_ == True:
-        # 単純な数値は認識されない？
-        return price*count*(1+tax/100.0)
-    else:
-        return price*count
+def multiplyTaxIncluded(price, count):
+    return price*count
 
 
-def profit(price, count, isTax, tax, cost):
-    return multiply(price, count, isTax, tax)-(cost*count)
+def profit(price, count, tax, cost):
+    return multiply(price, count, tax)-(cost*count)
+
+
+def profitTaxIncluded(price, count, cost):
+    return multiplyTaxIncluded(price, count)-(cost*count)
 
 
 @app.route('/v1/achievements-group', methods=['GET'])
@@ -533,17 +532,26 @@ def invoice_achievement_group_v1():
     req = request.args
     reqMonth = int(req.get('month')) if req.get('month') else None
     reqYear = int(req.get('year')) if req.get('year') else None
+    isTax = bool(int(req.get('isTax')))
 
     if reqYear and reqMonth:
         beforeDate = date(reqYear, reqMonth, 1)
         afterDate = beforeDate + \
             relativedelta.relativedelta(
                 years=1)-relativedelta.relativedelta(days=1)
-        achievements = db.session.query(func.strftime(
-            "%Y-%m", Invoice.applyDate).label("applyDate"), func.sum(multiply(Invoice_Item.price, Invoice_Item.count, Invoice.isTaxExp, Invoice.tax)).label("monthlySales"),
-            func.sum(profit(Invoice_Item.price, Invoice_Item.count, Invoice.isTaxExp, Invoice.tax, Invoice_Item.cost)).label("monthlyProfit")) \
-            .filter(and_(Invoice.isDelete == False, Invoice.applyDate.between(beforeDate, afterDate))) \
-            .join(Invoice_Item).group_by(func.strftime("%Y-%m", Invoice.applyDate)).all()
+        # func.sum内でInvoice.isTaxのbool値が使えないので
+        if isTax:
+            achievements = db.session.query(func.strftime(
+                "%Y-%m", Invoice.applyDate).label("applyDate"), func.sum(multiply(Invoice_Item.price, Invoice_Item.count, Invoice.tax)).label("monthlySales"),
+                func.sum(profit(Invoice_Item.price, Invoice_Item.count, Invoice.tax, Invoice_Item.cost)).label("monthlyProfit")) \
+                .filter(and_(Invoice.isDelete == False, Invoice.isTaxExp == True, Invoice.applyDate.between(beforeDate, afterDate))) \
+                .join(Invoice_Item).group_by(func.strftime("%Y-%m", Invoice.applyDate)).all()
+        else:
+            achievements = db.session.query(func.strftime(
+                "%Y-%m", Invoice.applyDate).label("applyDate"), func.sum(multiplyTaxIncluded(Invoice_Item.price, Invoice_Item.count,)).label("monthlySales"),
+                func.sum(profitTaxIncluded(Invoice_Item.price, Invoice_Item.count, Invoice_Item.cost)).label("monthlyProfit")) \
+                .filter(and_(Invoice.isDelete == False, Invoice.isTaxExp == False, Invoice.applyDate.between(beforeDate, afterDate))) \
+                .join(Invoice_Item).group_by(func.strftime("%Y-%m", Invoice.applyDate)).all()
 
     else:
         achievements = Invoice.query.filter(Invoice.isDelete == False)

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -61,13 +61,12 @@
                   :items=achievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'applyDate', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: 'monthlySales', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: 'monthlyProfit', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'monthlySales_sum', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'monthlyProfit_sum', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'monthlyCostRate', label: '粗利率', thClass: 'text-center', tdClass: 'text-center' },
                         ]">
                   <template v-slot:cell(monthlyCostRate)="data">
-                    {{monthlyCostRate(data.item.monthlyProfit,data.item.monthlySales)}}%
-                    <!-- {{data.item.monthlyCostRate}}% -->
+                    {{monthlyCostRate(data.item.monthlyProfit_sum,data.item.monthlySales_sum)}}%
                   </template>
                 </b-table>
               </b-card>
@@ -94,24 +93,17 @@
           getAchievements: async function (year = null, month = null) {
             self = this;
             url = '/v1/achievements-group'
-            // url = '/v1/achievements'
+            let mergedJson;
             await axios.get(url, {
               params: {
                 year: year,
                 month: month,
+                isTax: 1,
               }
             })
               .then(function (response) {
                 console.log(response);
-                self.achievements = response.data;
-                df = new dfd.DataFrame(self.achievements,)
-                df.print();
-                if (df['applyDate'] !== undefined) {
-                  df.setIndex({ index: df['applyDate'].values, inplace: true })
-                  df.drop({ columns: ['applyDate'], inplace: true })
-                  df.plot("achievement-chart").bar({ columns: ["monthlyProfit", "monthlySales"] })
-                }
-                else df.plot("achievement-chart").bar({ columns: ["monthlyProfit", "monthlySales"] })
+                mergedJson = response.data;
                 // 原価率計算
                 // let achievements = self.achievements;
                 // achievements.map(achieve => {
@@ -119,6 +111,26 @@
                 // });
                 // self.achievements = achievements;
               });
+            await axios.get(url, {
+              params: {
+                year: year,
+                month: month,
+                isTax: 0,
+              }
+            })
+              .then(function (response) {
+                console.log(response);
+                response.data.map(d => mergedJson.push(d));
+                console.log(mergedJson);
+              });
+            df = new dfd.DataFrame(mergedJson).groupby(['applyDate']).sum();
+            df.print();
+            if (df['applyDate'] !== undefined) {
+              df.setIndex({ index: df['applyDate'].values, inplace: true })
+              df.drop({ columns: ['applyDate'], inplace: true })
+            }
+            df.plot("achievement-chart").bar({ columns: ["monthlyProfit_sum", "monthlySales_sum"] })
+            self.achievements = dfd.toJSON(df);
           },
           monthlyCostRate: function (monthlyProfit, monthlySales) {
             return Math.round(monthlyProfit / monthlySales * 100);

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -124,13 +124,13 @@
                 console.log(mergedJson);
               });
             df = new dfd.DataFrame(mergedJson).groupby(['applyDate']).sum();
+            self.achievements = dfd.toJSON(df);
             df.print();
             if (df['applyDate'] !== undefined) {
               df.setIndex({ index: df['applyDate'].values, inplace: true })
               df.drop({ columns: ['applyDate'], inplace: true })
             }
             df.plot("achievement-chart").bar({ columns: ["monthlyProfit_sum", "monthlySales_sum"] })
-            self.achievements = dfd.toJSON(df);
           },
           monthlyCostRate: function (monthlyProfit, monthlySales) {
             return Math.round(monthlyProfit / monthlySales * 100);


### PR DESCRIPTION
関連Issue：グラフページの作成 #1104

実績ページに月間粗利率を追加。月間請求合計に消費税を適用しようとしているがうまくいかない。 #1137
このプルリクで発生していた、実績API内のSQLで消費税の有無で計算式を変える事が出来なかったが、別のアプローチで解消。
実績API(/achievemments-group)内で分岐を行うようにして、APIを2回呼び出し。呼び出された結果をフロント側でgroupby.sum()した。