### PR TITLE
請求金額・粗利額の合計がnullのものがあると売上ページでエラーが出るのを解消。

### DIFF
--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -91,6 +91,7 @@
     <script>
       Vue.filter('nf', function (val) {
         if (isNaN(val)) return null
+        if (val === null) return 0;
         return val.toLocaleString();
       });
 


### PR DESCRIPTION
請求金額・粗利金額それぞれ月の合計がnullになってしまっている状態だと、合計金額にコンマを付ける処理でエラーが出たので、それを解消した。