### PR TITLE
売上ページのグラフ表示はデフォルトで行うようにした。グラフボタン廃止。

### DIFF
--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -154,37 +154,14 @@
             }).value();
             console.log(self.achievements);
 
-            self.applyDateList, self.monthlySalesList, self.monthlyProfitList = []
+            self.applyDateList = [], self.monthlySalesList = [], self.monthlyProfitList = []
             self.achievements.forEach(achieve => {
               self.applyDateList.push(achieve.applyDate);
               self.monthlySalesList.push(achieve.monthlySales_sum);
               self.monthlyProfitList.push(achieve.monthlyProfit_sum);
             });
             console.log(self.applyDateList, self.monthlyProfitList, self.monthlySalesList);
-
-            // グラフ表示
-            let ctx = document.getElementById("achievement-chart");
-            self.myChart = new Chart(ctx, {
-              data: {
-                labels: self.applyDateList,
-                datasets: [
-                  {
-                    type: 'bar',
-                    label: '当期累計',
-                    data: self.monthlySalesList,
-                    borderColor: "rgba(254,97,132,0.8)",
-                    backgroundColor: "rgba(254,97,132,0.5)",
-                  },
-                  {
-                    type: 'line',
-                    label: '粗利額',
-                    data: self.monthlyProfitList,
-                    borderColor: "rgba(54,164,235,0.8)",
-                    backgroundColor: "rgba(54,164,235,0.5)",
-                  },
-                ]
-              }
-            });
+            this.plot();
 
             // ----- danfo.js -----
             // df = new dfd.DataFrame(mergedJson)
@@ -208,33 +185,33 @@
             if (isNaN(monthlyCostRate)) monthlyCostRate = 0;
             return monthlyCostRate;
           },
-          // plot(type1, type2) {
-          //   if (self.myChart) {
-          //     self.myChart.destroy();
-          //   }
-          //   let ctx = document.getElementById("achievement-chart");
-          //   self.myChart = new Chart(ctx, {
-          //     data: {
-          //       labels: self.applyDateList,
-          //       datasets: [
-          //         {
-          //           type: type1,
-          //           label: '当期累計',
-          //           data: self.monthlySalesList,
-          //           borderColor: "rgba(254,97,132,0.8)",
-          //           backgroundColor: "rgba(254,97,132,0.5)",
-          //         },
-          //         {
-          //           type: type2,
-          //           label: '粗利額',
-          //           data: self.monthlyProfitList,
-          //           borderColor: "rgba(54,164,235,0.8)",
-          //           backgroundColor: "rgba(54,164,235,0.5)",
-          //         },
-          //       ]
-          //     }
-          //   });
-          // },
+          plot() {
+            if (self.myChart) {
+              self.myChart.destroy();
+            }
+            let ctx = document.getElementById("achievement-chart");
+            self.myChart = new Chart(ctx, {
+              data: {
+                labels: self.applyDateList,
+                datasets: [
+                  {
+                    type: 'bar',
+                    label: '当期累計',
+                    data: self.monthlySalesList,
+                    borderColor: "rgba(254,97,132,0.8)",
+                    backgroundColor: "rgba(254,97,132,0.5)",
+                  },
+                  {
+                    type: 'line',
+                    label: '粗利額',
+                    data: self.monthlyProfitList,
+                    borderColor: "rgba(54,164,235,0.8)",
+                    backgroundColor: "rgba(54,164,235,0.5)",
+                  },
+                ]
+              }
+            });
+          },
         },
         mounted: function () {
           document.querySelector('title').textContent = '売上実績';

--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -77,10 +77,10 @@
                   </template>
                 </b-table>
               </b-card>
-              <b-button variant="primary" size="sm" @click="plot('bar','line')">棒＋線グラフ</b-button>
+              <!-- <b-button variant="primary" size="sm" @click="plot('bar','line')">棒＋線グラフ</b-button>
               <b-button variant="primary" size="sm" @click="plot('bar','bar')">棒グラフ</b-button>
               <b-button variant="primary" size="sm" @click="plot('line','line')">線グラフ</b-button>
-              <b-button variant="primary" size="sm" @click="plot('doughnut','doughnut')">円グラフ</b-button>
+              <b-button variant="primary" size="sm" @click="plot('doughnut','doughnut')">円グラフ</b-button> -->
             </b-col>
             <b-col></b-col>
           </b-row>
@@ -162,6 +162,30 @@
             });
             console.log(self.applyDateList, self.monthlyProfitList, self.monthlySalesList);
 
+            // グラフ表示
+            let ctx = document.getElementById("achievement-chart");
+            self.myChart = new Chart(ctx, {
+              data: {
+                labels: self.applyDateList,
+                datasets: [
+                  {
+                    type: 'bar',
+                    label: '当期累計',
+                    data: self.monthlySalesList,
+                    borderColor: "rgba(254,97,132,0.8)",
+                    backgroundColor: "rgba(254,97,132,0.5)",
+                  },
+                  {
+                    type: 'line',
+                    label: '粗利額',
+                    data: self.monthlyProfitList,
+                    borderColor: "rgba(54,164,235,0.8)",
+                    backgroundColor: "rgba(54,164,235,0.5)",
+                  },
+                ]
+              }
+            });
+
             // ----- danfo.js -----
             // df = new dfd.DataFrame(mergedJson)
             // if (mergedJson.length !== 0)
@@ -184,34 +208,33 @@
             if (isNaN(monthlyCostRate)) monthlyCostRate = 0;
             return monthlyCostRate;
           },
-          // type1,type2:グラフの形式
-          plot(type1, type2) {
-            if (self.myChart) {
-              self.myChart.destroy();
-            }
-            let ctx = document.getElementById("achievement-chart");
-            self.myChart = new Chart(ctx, {
-              data: {
-                labels: self.applyDateList,
-                datasets: [
-                  {
-                    type: type1,
-                    label: '当期累計',
-                    data: self.monthlySalesList,
-                    borderColor: "rgba(254,97,132,0.8)",
-                    backgroundColor: "rgba(254,97,132,0.5)",
-                  },
-                  {
-                    type: type2,
-                    label: '粗利額',
-                    data: self.monthlyProfitList,
-                    borderColor: "rgba(54,164,235,0.8)",
-                    backgroundColor: "rgba(54,164,235,0.5)",
-                  },
-                ]
-              }
-            });
-          },
+          // plot(type1, type2) {
+          //   if (self.myChart) {
+          //     self.myChart.destroy();
+          //   }
+          //   let ctx = document.getElementById("achievement-chart");
+          //   self.myChart = new Chart(ctx, {
+          //     data: {
+          //       labels: self.applyDateList,
+          //       datasets: [
+          //         {
+          //           type: type1,
+          //           label: '当期累計',
+          //           data: self.monthlySalesList,
+          //           borderColor: "rgba(254,97,132,0.8)",
+          //           backgroundColor: "rgba(254,97,132,0.5)",
+          //         },
+          //         {
+          //           type: type2,
+          //           label: '粗利額',
+          //           data: self.monthlyProfitList,
+          //           borderColor: "rgba(54,164,235,0.8)",
+          //           backgroundColor: "rgba(54,164,235,0.5)",
+          //         },
+          //       ]
+          //     }
+          //   });
+          // },
         },
         mounted: function () {
           document.querySelector('title').textContent = '売上実績';


### PR DESCRIPTION
関連Issue：売上ページはデフォルトでグラフ表示で良い #1176

- 売上ページのグラフ表示はデフォルトで行うようにした
- グラフボタン廃止。グラフは棒＋線グラフで統一
- 売上実績の範囲検索時にグラフが更新されるようにした。