### PR TITLE
設定ページの各種ページ。リンクボタンをヘッダーに移動。

### DIFF
--- a/app/static/component/menu-header.js
+++ b/app/static/component/menu-header.js
@@ -27,3 +27,54 @@ Vue.component('menu-header', {
         modeName: String,
     },
 })
+
+Vue.component('setting-header', {
+    template: `
+    <div>
+        <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
+            <b-row>
+                <b-col></b-col>
+                <b-col cols="11">
+                    <b-row>
+                        <b-col class="pc-mode">
+                            <b-button href="/setting-page">会社情報</b-button>
+                            <b-button href="/user-page">ユーザー</b-button>
+                            <b-button href="/category-page">カテゴリ</b-button>
+                            <b-button href="/maker-page">メーカー</b-button>
+                            <b-button href="/unit-page">単位</b-button>
+                            <b-button href="/dust-select-page">削除済み</b-button>
+                        </b-col>
+                        <b-col class="sm-mode">
+                            <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                                <b-icon icon="building"></b-icon>
+                            </b-button>
+                            <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
+                                <b-icon icon="person-plus-fill"></b-icon>
+                            </b-button>
+                            <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
+                                <b-icon icon="folder2"></b-icon>
+                            </b-button>
+                            <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
+                                <b-icon icon="shop"></b-icon>
+                            </b-button>
+                            <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
+                                <b-icon icon="hammer"></i>
+                            </b-button>
+                            <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
+                                <b-icon icon="file-earmark-x"></b-icon>
+                            </b-button>
+                        </b-col>
+                        <b-col cols="2" class="text-right">
+                            <sc-menu v-if="modeName!='mw'"></sc-menu>
+                        </b-col>
+                    </b-row>
+                </b-col>
+                <b-col></b-col>
+            </b-row>
+        </b-card>
+    </div>
+    `,
+    props: {
+        modeName: String,
+    },
+})

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -33,7 +33,7 @@
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
                 <!-- ヘッダー -->
-                <menu-header :main-add-row="CategoryAddRow" :mode-name="modeName"></menu-header>
+                <setting-header :mode-name="modeName"></setting-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -44,6 +44,13 @@
                     <b-col cols="11">
                         <b-card border-variant="white" class="mb-3 text-center" header="カテゴリ一覧"
                             header-border-variant="light">
+                            <b-row align-h="start">
+                                <router-link to="?page=store">
+                                    <b-button pill variant="success" class="mb-3 ml-3" @click="CategoryAddRow();">
+                                        ＋新規
+                                    </b-button>
+                                </router-link>
+                            </b-row>
                             <b-table responsive hover small id="categorytable" sort-by="ID" small label="Table Options"
                                 :items=categories :fields="[
                           {  key: 'update', label: '' },
@@ -101,8 +108,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show' || pageName=='store'">
+            <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getCategories();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
@@ -114,36 +122,6 @@
                         <b-button pill size="lg" variant="danger" @click="modalShow(category,'deleteModal');"
                             v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
-                        </b-button>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/dust_select.html
+++ b/app/templates/dust_select.html
@@ -26,22 +26,7 @@
         </style>
 
         <div id="app" v-cloak>
-            <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                <b-row>
-                    <b-col></b-col>
-                    <b-col cols="11">
-                        <b-row>
-                            <b-col>
-                            </b-col>
-                            <!-- サイドバー -->
-                            <b-col cols="1" class="text-right">
-                                <sc-menu v-if="modeName!='mw'"></sc-menu>
-                            </b-col>
-                        </b-row>
-                    </b-col>
-                    <b-col></b-col>
-                </b-row>
-            </b-card>
+            <setting-header :mode-name="modeName"></setting-header>
 
             <!-- 空行 -->
             <b-row class="mb-5"></b-row>
@@ -62,39 +47,6 @@
                     <b-col></b-col>
                 </b-row>
             </div>
-
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
-                        </b-button>
-                    </b-col>
-                </b-row>
-            </b-card>
 
         </div>
 

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -53,22 +53,7 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <setting-header :mode-name="modeName"></setting-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -356,8 +341,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show'">
+            <b-card v-if="pageName=='show'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getInvoices(searchInvoiceWord);" v-b-tooltip.hover.top="'戻る'">＜
@@ -372,16 +358,6 @@
                             </template>
                             <b-dropdown-item @click="pdfout('delivery')">納品書</b-dropdown-item>
                         </b-dropdown>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/dust-select-page">＜</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/dust-select-page">
-                            <b-icon icon="chevron-left"></b-icon>
-                        </b-button>
                     </b-col>
                 </b-row>
             </b-card>

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -32,7 +32,7 @@
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
                 <!-- ヘッダー -->
-                <menu-header :main-add-row="MakerAddRow" :mode-name="modeName"></menu-header>
+                <setting-header :mode-name="modeName"></setting-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -43,6 +43,13 @@
                     <b-col cols="11">
                         <b-card border-variant="white" class="mb-3 text-center" header="メーカー一覧"
                             header-border-variant="light">
+                            <b-row align-h="start">
+                                <router-link to="?page=store">
+                                    <b-button pill variant="success" class="mb-3 ml-3" @click="MakerAddRow();">
+                                        ＋新規
+                                    </b-button>
+                                </router-link>
+                            </b-row>
                             <b-table responsive hover small id="makertable" sort-by="ID" small label="Table Options"
                                 :items=makers :fields="[
                           {  key: 'update', label: '' },
@@ -98,8 +105,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show' || pageName=='store'">
+            <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getMakers();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
@@ -111,36 +119,6 @@
                         <b-button pill size="lg" variant="danger" @click="modalShow(maker,'deleteModal');"
                             v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
-                        </b-button>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -53,22 +53,7 @@
         <div id="app" v-cloak>
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
-                <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                    <b-row>
-                        <b-col></b-col>
-                        <b-col cols="11">
-                            <b-row>
-                                <b-col>
-                                </b-col>
-                                <!-- サイドバー -->
-                                <b-col cols="1" class="text-right">
-                                    <sc-menu v-if="modeName!='mw'"></sc-menu>
-                                </b-col>
-                            </b-row>
-                        </b-col>
-                        <b-col></b-col>
-                    </b-row>
-                </b-card>
+                <setting-header :mode-name="modeName"></setting-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -346,8 +331,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show'">
+            <b-card v-if="pageName=='show'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getQuotations(searchQuotationWord);" v-b-tooltip.hover.top="'戻る'">＜
@@ -357,16 +343,6 @@
                     <b-col class="text-right">
                         <b-button pill size="lg" variant="primary" @click="pdfout" id="pdfout"
                             v-b-tooltip.hover.top="'印刷'"><i class="fas fa-print"></i>
-                        </b-button>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/dust-select-page">＜</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/dust-select-page">
-                            <b-icon icon="chevron-left"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -27,22 +27,7 @@
 
 
         <div id="app" v-cloak>
-            <b-card class="fixed-top header" style="background: rgba(255,255,255,0.5);">
-                <b-row>
-                    <b-col></b-col>
-                    <b-col cols="11">
-                        <b-row>
-                            <b-col>
-                            </b-col>
-                            <!-- サイドバー -->
-                            <b-col class="text-right">
-                                <sc-menu v-if="modeName!='mw'"></sc-menu>
-                            </b-col>
-                        </b-row>
-                    </b-col>
-                    <b-col></b-col>
-                </b-row>
-            </b-card>
+            <setting-header :mode-name="modeName"></setting-header>
 
             <!-- 空行 -->
             <b-row class="mb-5"></b-row>
@@ -297,39 +282,8 @@
             <!-- 更新・取消ボタンのフッター -->
             <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
                 <b-row>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                        <b-button href="https://mail-form.site/contact/soho-caddie" target="_blank">お問合わせ</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
-                        </b-button>
-                        <b-button href="https://mail-form.site/contact/soho-caddie" target="_blank"
-                            v-b-tooltip.hover.top="'お問い合わせ'">
-                            <b-img src="../static/images/icon/contact.png" style="width: 20px;"></b-img>
-                        </b-button>
-                    </b-col>
+                    <b-col></b-col>
+                    <b-col></b-col>
                     <b-col cols="4" class="text-right">
                         <b-button variant="primary" class="mr-3" @click="bulkUpsert(setting);showConfirmModal();">保存
                         </b-button>

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -33,7 +33,7 @@
             <!-- 一覧表示 -->
             <div v-if="pageName=='index'">
                 <!-- ヘッダー -->
-                <menu-header :main-add-row="UnitAddRow" :mode-name="modeName"></menu-header>
+                <setting-header :mode-name="modeName"></setting-header>
 
                 <!-- 空行 -->
                 <b-row class="mb-5"></b-row>
@@ -44,6 +44,13 @@
                     <b-col cols="11">
                         <b-card border-variant="white" class="mb-3 text-center" header="単位一覧"
                             header-border-variant="light">
+                            <b-row align-h="start">
+                                <router-link to="?page=store">
+                                    <b-button pill variant="success" class="mb-3 ml-3" @click="UnitAddRow();">
+                                        ＋新規
+                                    </b-button>
+                                </router-link>
+                            </b-row>
                             <b-table responsive hover small id="unittable" sort-by="ID" small label="Table Options"
                                 :items=units :fields="[
                           {  key: 'update', label: '' },
@@ -99,8 +106,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show' || pageName=='store'">
+            <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getUnits();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
@@ -112,36 +120,6 @@
                         <b-button pill size="lg" variant="danger" @click="modalShow(unit,'deleteModal');"
                             v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
-                        </b-button>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -38,11 +38,38 @@
                         <b-col></b-col>
                         <b-col cols="11">
                             <b-row>
-                                <b-col></b-col>
-                                <b-col class="text-right">
+                                <b-col class="pc-mode">
+                                    <b-button href="/setting-page">会社情報</b-button>
+                                    <b-button href="/user-page">ユーザー</b-button>
+                                    <b-button href="/category-page">カテゴリ</b-button>
+                                    <b-button href="/maker-page">メーカー</b-button>
+                                    <b-button href="/unit-page">単位</b-button>
+                                    <b-button href="/dust-select-page">削除済み</b-button>
+                                </b-col>
+                                <b-col class="sm-mode">
+                                    <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
+                                        <b-icon icon="building"></b-icon>
+                                    </b-button>
+                                    <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
+                                        <b-icon icon="person-plus-fill"></b-icon>
+                                    </b-button>
+                                    <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
+                                        <b-icon icon="folder2"></b-icon>
+                                    </b-button>
+                                    <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
+                                        <b-icon icon="shop"></b-icon>
+                                    </b-button>
+                                    <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
+                                        <b-icon icon="hammer"></i>
+                                    </b-button>
+                                    <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
+                                        <b-icon icon="file-earmark-x"></b-icon>
+                                    </b-button>
+                                </b-col>
+                                <b-col cols="3" class="text-right">
                                     <b-button @click="$bvModal.show('login-history-modal')">ログ履歴</b-button>
                                 </b-col>
-                                <b-col cols="1" class="text-right">
+                                <b-col cols="2" class="text-right">
                                     <sc-menu v-if="modeName!='mw'"></sc-menu>
                                 </b-col>
                             </b-row>
@@ -191,8 +218,9 @@
             <b-row class="mb-5"></b-row>
 
             <!-- 更新・取消ボタンのフッター -->
-            <b-card text-variant="white" class="fixed-bottom footer" style="background: rgba(52,58,64,0.9);">
-                <b-row v-if="pageName=='show' || pageName=='store'">
+            <b-card v-if="pageName=='show' || pageName=='store'" text-variant="white" class="fixed-bottom footer"
+                style="background: rgba(52,58,64,0.9);">
+                <b-row>
                     <b-col>
                         <router-link to="?page=index">
                             <b-button @click="getUsers();" v-b-tooltip.hover.top="'戻る'">＜</b-button>
@@ -204,36 +232,6 @@
                         <b-button pill size="lg" variant="danger" @click="modalShow(user,'deleteModal');"
                             v-b-tooltip.hover.top="'削除'">
                             <i class="fas fa-trash-alt"></i>
-                        </b-button>
-                    </b-col>
-                </b-row>
-                <b-row v-else>
-                    <b-col class="pc-mode">
-                        <b-button href="/setting-page">会社情報</b-button>
-                        <b-button href="/user-page">ユーザー</b-button>
-                        <b-button href="/category-page">カテゴリ</b-button>
-                        <b-button href="/maker-page">メーカー</b-button>
-                        <b-button href="/unit-page">単位</b-button>
-                        <b-button href="/dust-select-page">削除済み</b-button>
-                    </b-col>
-                    <b-col class="sm-mode">
-                        <b-button href="/setting-page" v-b-tooltip.hover.top="'会社情報'">
-                            <b-icon icon="building"></b-icon>
-                        </b-button>
-                        <b-button href="/user-page" v-b-tooltip.hover.top="'ユーザー登録'">
-                            <b-icon icon="person-plus-fill"></b-icon>
-                        </b-button>
-                        <b-button href="/category-page" v-b-tooltip.hover.top="'カテゴリ登録'">
-                            <b-icon icon="folder2"></b-icon>
-                        </b-button>
-                        <b-button href="/maker-page" v-b-tooltip.hover.top="'メーカー登録'">
-                            <b-icon icon="shop"></b-icon>
-                        </b-button>
-                        <b-button href="/unit-page" v-b-tooltip.hover.top="'単位登録'">
-                            <b-icon icon="hammer"></i>
-                        </b-button>
-                        <b-button href="/dust-select-page" v-b-tooltip.hover.top="'削除済み参照'">
-                            <b-icon icon="file-earmark-x"></b-icon>
                         </b-button>
                     </b-col>
                 </b-row>


### PR DESCRIPTION
関連Issue：ヘッダーとフッターの仕様変更。 #1180

- 設定ページ用ヘッダーコンポーネント作成
- 設定ページの各種ページ。リンクボタンを配置しているフッターを廃止（会社情報のみフッターを残す）
- 設定ページの各種ページ。リンクボタンをヘッダーに配置。
- 新規ボタンを一覧テーブルの上に配置。