### PR TITLE
請求書の明細追加後に原価を入力しないとエラーになるのを解消

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -668,8 +668,11 @@ def invoice_update(id):
             if 'updatedAt' in item:
                 del(item['updatedAt'])
             for columnName in item.keys():
-                if item[columnName] == '':
-                    item[columnName] = None
+                if columnName == 'cost':
+                    if item['cost'] == '' or item['cost'] == None:
+                        item['cost'] = 0
+                    elif item[columnName] == '':
+                        item[columnName] = None
 
             if item.get('id'):
                 if item.get('isDelete'):

--- a/app/api.py
+++ b/app/api.py
@@ -671,8 +671,8 @@ def invoice_update(id):
                 if columnName == 'cost':
                     if item['cost'] == '' or item['cost'] == None:
                         item['cost'] = 0
-                    elif item[columnName] == '':
-                        item[columnName] = None
+                elif item[columnName] == '':
+                    item[columnName] = None
 
             if item.get('id'):
                 if item.get('isDelete'):


### PR DESCRIPTION
関連Issue：請求書にて内容項目の6行目以降入力して保存ボタンを押しても反応せず保存できない。

フロント側で請求書明細を追加すると、リクエストの中にはInvoice_Items.costが含まれないので起きていたエラーだった。