### PR TITLE
さらに表示判定用レスポンス作成（サンプル）

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -469,6 +469,9 @@ def invoice_index_v1():
         invoices = invoices.offset(offset)
     if limit:
         invoices = invoices.limit(limit)
+    totalRecordCount = invoices.count()
+    nowRecordCount = limit+(limit*offset)
+    isMore = True if nowRecordCount < totalRecordCount else False
 
     newHistory = History(
         userName=current_user.id,
@@ -478,7 +481,7 @@ def invoice_index_v1():
     )
     db.session.add(newHistory)
     db.session.commit()
-    return jsonify(InvoiceSchema(many=True).dump(invoices))
+    return jsonify({'invoices': InvoiceSchema(many=True).dump(invoices), 'isMore': isMore})
 
 
 @app.route('/v1/dust-invoices', methods=['GET'])

--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -32,7 +32,7 @@ var search = Vue.component('search', {
             })
                 .then(function (response) {
                     console.log(response);
-                    search.invoices = response.data;
+                    search.invoices = response.data.invoices;
                     self.countChanged = 0;
                 });
             this.changeInvoices();

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -754,7 +754,7 @@
                                 console.log(response);
                                 if (offset == 0) {
                                     self.offset = 0;
-                                    self.invoices = response.data;
+                                    self.invoices = response.data.invoices;
                                 }
                                 else {
                                     response.data.map(invoice => self.invoices.push(invoice));


### PR DESCRIPTION
関連Issue：「さらに表示」は件数が300件以上の時に表示させる #1198

この実装のために、isMoreという項目を追加したレスポンスを作成してみた。
この方法でのデメリットは、axios.thenで返ってきたレスポンスが　data{[{},{},{}]}　ではなく
data:{'invoices':[{},{},{},],'isMore',false}　となってしまうので response.data.invoicesと書き換えないといけない点。

他に良い方法があれば教えて欲しい。