### PR TITLE
売上ページの一覧ヘッダー。「当期累計」を「月次累計」に変更。

### DIFF
--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -55,7 +55,7 @@
                   :items=achievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'applyDate', label: '当期', thClass: 'text-center', tdClass: 'text-center' },
-                          {  key: 'monthlySales_sum', label: '当期累計', thClass: 'text-center', tdClass: 'text-center' },
+                          {  key: 'monthlySales_sum', label: '月次累計', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'monthlyProfit_sum', label: '粗利額', thClass: 'text-center', tdClass: 'text-center' },
                           {  key: 'monthlyCostRate', label: '粗利率', thClass: 'text-center', tdClass: 'text-center' },
                         ]">


### PR DESCRIPTION
関連Issue：売上ページの一覧。ヘッダーの当期累計を「月次累計」に変更。 #1178