### PR TITLE
明細追加・削除ロジックの大幅変更。途中まで。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -639,6 +639,8 @@ def invoice_update(id):
     data = request.json
 
     invoice = Invoice.query.filter(Invoice.id == id).one()
+    invoiceItemsIds = db.session.query(Invoice_Item.id).filter(
+        Invoice_Item.invoiceId == id).all()
     if not invoice:
         return jsonify({"result": "No Data", "id": id, "data": data})
 
@@ -671,6 +673,8 @@ def invoice_update(id):
         update_list = []
         insert_list = []
         delete_in_list = []
+        for i in invoiceItemsIds:
+            delete_in_list.append(i.id)
         for item in data['invoice_items']:
             if 'createdAt' in item:
                 del(item['createdAt'])
@@ -684,15 +688,20 @@ def invoice_update(id):
                     item[columnName] = None
 
             if item.get('id'):
-                if item.get('isDelete'):
-                    delete_in_list.append(item['id'])
-                else:
-                    update_list.append(item)
+                update_list.append(item)
+                index = next((i for i, x in enumerate(
+                    delete_in_list) if x == item['id']), None)
+                if index != None:
+                    delete_in_list.pop(index)
+                # if item.get('isDelete'):
+                #     delete_in_list.append(item['id'])
+                # else:
+                #     update_list.append(item)
             else:
-                if item.get('isDelete'):
-                    pass
-                else:
-                    insert_list.append(item)
+                # if item.get('isDelete'):
+                #     pass
+                # else:
+                insert_list.append(item)
 
         db.session.bulk_update_mappings(Invoice_Item, update_list)
         db.session.bulk_insert_mappings(Invoice_Item, insert_list)

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -311,6 +311,7 @@
                           {  key: 'price', label: '値段', tdClass:'td-price' },
                           {  key: 'amount', label: '金額' },
                           {  key: 'detail', label: '詳細',class:'text-center' },
+                          {  key: 'addRow', label: '追加',class:'text-center' },
                           {  key: 'isDelete', label: '削除',class:'text-center' },
                         ]">
 
@@ -432,18 +433,22 @@
                                 </b-row>
                             </template>
 
+                            <template v-slot:cell(addRow)="data">
+                                <b-button size="sm" @click="addRowInvoiceItem(data);">✙</b-button>
+                            </template>
                             <template v-slot:cell(isDelete)="data">
-                                <b-form-checkbox v-model="data.item.isDelete"></b-form-checkbox>
+                                <b-button size="sm" @click="subRowInvoiceItem(data)">－</b-button>
+                                <!-- <b-form-checkbox v-model="data.item.isDelete"></b-form-checkbox> -->
                             </template>
 
                         </b-table>
 
                         <!-- 商品項目を追加するプラスボタン -->
-                        <b-row class="d-flex justify-content-end" id="item_add">
+                        <!-- <b-row class="d-flex justify-content-end" id="item_add">
                             <b-col cols="16" md="auto">
                                 <b-button pill variant="primary" @click="addRowInvoiceItem();">✙</b-button>
                             </b-col>
-                        </b-row>
+                        </b-row> -->
 
                         <div class="mt-5"></div>
 
@@ -900,14 +905,19 @@
                                 }
                             });
                     },
-                    addRowInvoiceItem: function () {
+                    addRowInvoiceItem: function (data) {
                         if (this.invoice.length === 0) {
                             alert('請求書を選択してください');
                             return;
                         }
-                        this.invoice.invoice_items.push({
-                            invoiceId: this.invoice.id
-                        })
+                        this.invoice.invoice_items.splice(data.index + 1, 0, { invoiceId: this.invoice.id, })
+                    },
+                    subRowInvoiceItem: function (data) {
+                        if (this.invoice.length === 0) {
+                            alert('請求書を選択してください');
+                            return;
+                        }
+                        this.invoice.invoice_items.splice(data.index + 1, 1)
                     },
                     addRowInvoicePayment: function () {
                         if (this.invoice.length === 0) {


### PR DESCRIPTION
関連Issue：請求・見積の明細欄。追加と削除機能の動作を大幅変更。 #1194

明細欄で追加した行番号とテーブルのインデックス番号が同期しない状態になってしまう。
請求書保存時に、請求書に紐づく明細のDBデータを一旦削除して、１から明細データをinsertしなおそうと考えているのだが、悪手だろうか？
明細idが振りなおされる事で、テーブルのインデックスと明細idが同期する事はできるような気がしている。