### PR TITLE
設定ページで登録番号が空白だと保存できなくなるバグを修正。

### DIFF
--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -356,6 +356,7 @@
                 methods: {
                     // ---Settings---
                     bulkUpsert(item) {
+                        if (!item.registerNumber) item.registerNumber = '';
                         if (item.registerNumber.length > 13) {
                             this.title = 'エラー';
                             this.message = '登録番号は１３桁以下で入力してください';


### PR DESCRIPTION
関連Issue：設定ページでロゴ削除ボタンを押下した後に保存できないらしい。 #1233

原因はただ単に登録番号が空白の状態だとそれを参照できなくなるのでエラーが出ていただけだった。