### PR TITLE
画面をクリックするとセッションのライフタイムが回復するようにした

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -107,6 +107,11 @@ def is_session():
         return jsonify({"session": False})
 
 
+@app.route('/on-click', methods=['GET'])
+def onClick():
+    return jsonify({"result": "UpdateSession", })
+
+
 # ------　ユーザー認証ここまで -------
 
 

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -213,6 +213,22 @@
 
                 }
                 setInterval(polling_session, 30000)
+
+                // 画面クリック毎にセッションのライフタイム回復
+                $(function () {
+                    document.body.onclick = function (event) {
+                        url = "/on-click"
+                        const xhr = new XMLHttpRequest();
+                        xhr.open("GET", url, false);
+                        xhr.send(null);
+                        if (xhr.status == 200) {
+                            response = JSON.parse(xhr.responseText);
+                            console.log("response:", response)
+                        } else {
+                            console.log("any error");
+                        }
+                    }
+                });
             </script>
 
 </body>


### PR DESCRIPTION
関連Issue：自動ログアウトが若干早いらしい #1160

API呼び出し時にもライフタイムを更新しているので、本末転倒感はあるがこれでクリックアクション時にライフタイム更新がされる。