### PR TITLE
請求ページの得意先一覧は得意先任意番号で初期ソートするようにした

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -237,9 +237,9 @@
                                                 <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示
                                                 </b-form-checkbox>
                                             </b-row>
-                                            <b-table hover striped small sort-by="ID" id="customer-table"
-                                                :items="searchCustomers" @row-clicked="customerSelect"
-                                                label="Table Options" :fields="[
+                                            <b-table hover striped small id="customer-table" :items="searchCustomers"
+                                                @row-clicked="customerSelect" label="Table Options"
+                                                :sort-by.sync="this.sortByCustomers" :fields="[
                                                       {  key: 'anyNumber', label: 'No.' },
                                                       {  key: 'customerName', label: '得意先名' },
                                                 ]">
@@ -734,6 +734,7 @@
                 el: '#app',
                 data: {
                     sortByInvoices: 'id',
+                    sortByCustomers: 'anyNumber',
                     sortDesc: true,
                     searchInvoiceWord: "",
                     searchDayStart: '',             //請求書検索


### PR DESCRIPTION
関連Issue：請求書ページの得意先選択テーブルは得意先任意番号でソート。 #1260