### PR TITLE
得意先編集画面の請求書一覧はその得意先に紐づいたもののみ表示するようにした。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -133,18 +133,25 @@ def customer_index_v1():
     req = request.args
     searchWord = req.get('search')
     moreCheck = req.get('moreCheck') if req.get('moreCheck') else False
+    isInvoicesQuotations = req.get('isInvoicesQuotations') if req.get(
+        'isInvoicesQuotations') else False
     # テスト的に300に
     limit = int(req.get('limit')) if req.get('limit') else 300
     offset = int(req.get('offset')) if req.get('offset') else 0
     # 各種フィルタリング処理
+    # Booleanで渡ってこないので
+    if isInvoicesQuotations == 'true':
+        customers = Customer.query
+    else:
+        customers = db.session.query(Customer.id, Customer.anyNumber, Customer.closingMonth, Customer.customerName, Customer.customerKana, Customer.honorificTitle,
+                                     Customer.department, Customer.postNumber, Customer.address, Customer.addressSub, Customer.telNumber, Customer.faxNumber, Customer.url, Customer.email,
+                                     Customer.manager, Customer.representative, Customer.customerCategory, Customer.isHide, Customer.isFavorite, Customer.memo, Customer.createdAt, Customer.updatedAt,)
     if searchWord:
-        customers = Customer.query.filter(or_(
+        customers = customers.filter(or_(
             Customer.customerName.like('%'+searchWord+'%'),
             Customer.customerKana.like('%'+searchWord+'%'),
-            Customer.anyNumber == searchWord,
-        ))
-    else:
-        customers = Customer.query
+            Customer.anyNumber == searchWord,))
+
     customers_tmp = customers
     if offset:
         customers = customers.offset(offset)
@@ -172,9 +179,19 @@ def customer_index_v1():
 @app.route('/v1/customer/<id>', methods=['GET'])
 @app.route('/customer/<id>', methods=['GET'])
 def customer_show(id):
+    req = request.args
+    isInvoicesQuotations = req.get('isInvoicesQuotations') if req.get(
+        'isInvoicesQuotations') else False
     customerCount = Customer.query.filter(Customer.id == id).count()
     if customerCount:
-        customer = Customer.query.filter(Customer.id == id).first()
+        # Booleanで渡ってこないので
+        if isInvoicesQuotations == 'true':
+            customer = Customer.query
+        else:
+            customer = db.session.query(Customer.id, Customer.anyNumber, Customer.closingMonth, Customer.customerName, Customer.customerKana, Customer.honorificTitle,
+                                        Customer.department, Customer.postNumber, Customer.address, Customer.addressSub, Customer.telNumber, Customer.faxNumber, Customer.url, Customer.email,
+                                        Customer.manager, Customer.representative, Customer.customerCategory, Customer.isHide, Customer.isFavorite, Customer.memo, Customer.createdAt, Customer.updatedAt,)
+        customer = customer.filter(Customer.id == id).first()
         newHistory = History(
             userName=current_user.id,
             modelName='Customer',

--- a/app/models.py
+++ b/app/models.py
@@ -400,6 +400,12 @@ class CustomerSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = Customer
         include_fk = True
+
+
+class CustomerSchemaNestedInvoicesAndQuotations(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Customer
+        include_fk = True
     invoices = ma.Nested(InvoiceSchema, many=True)
     quotations = ma.Nested(QuotationSchema, many=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -52,10 +52,10 @@ class Customer(db.Model):
     createdAt = db.Column(db.DateTime, nullable=False, default=datetime.now)
     updatedAt = db.Column(db.DateTime, nullable=False,
                           default=datetime.now, onupdate=datetime.now)
-    # invoices = db.relationship(
-    #     'Invoice', backref='customer', uselist=True, cascade='all, delete',)
-    # quotations = db.relationship(
-    #     'Quotation', backref='customer', uselist=True, cascade='all, delete',)
+    invoices = db.relationship(
+        'Invoice', backref='customer', uselist=True, cascade='all, delete',)
+    quotations = db.relationship(
+        'Quotation', backref='customer', uselist=True, cascade='all, delete',)
 
 
 class Item(db.Model):

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -265,7 +265,7 @@
                                 </b-col>
                                 <b-col lg>
                                     <b-table responsive hover small id="invoicetable" label="Table Options"
-                                        :items=invoices sticky-header style="max-height: 500px;" :fields="[
+                                        :items=customer.invoices sticky-header style="max-height: 500px;" :fields="[
                                             {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                                             {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
                                             {  key: 'applyDate', label: '日付', thClass: 'th-apply-date text-center', tdClass: 'text-center', sortable: true },
@@ -281,10 +281,6 @@
                                             {{amountCalculation(data.item)|nf}}
                                         </template>
                                     </b-table>
-                                    <b-row align-h="end">
-                                        <b-button v-if="isMoreInvoices" variant="primary" size="sm"
-                                            @click="showMoreInvoices">さらに表示</b-button>
-                                    </b-row>
                                 </b-col>
                             </b-row>
                         </b-card>
@@ -353,15 +349,12 @@
                     customers: [],               //全件customer
                     customer: [],                //選択中のcustomer
                     oldCustomer: [],                //選択中の元customer
-                    invoices: [],
                     selectHonorificTitle: ['', '様', '御中', '殿',],    //敬称セレクトボックス用
                     closingMonth: [{ value: null, text: "" }, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
                     title: '',
                     message: '',
                     offset: 0,
                     isMore: false,
-                    offsetInvoices: 0,          //編集画面横の請求一覧用
-                    isMoreInvoices: false,      //編集画面横の請求一覧用
                 },
                 methods: {
                     // ---Customers---
@@ -466,15 +459,19 @@
                         self.customer = self.customers.slice(-1)[0];
                         localStorage.setItem('customer', JSON.stringify(self.customer))
                     },
-                    selectCustomer: function (item) {
-                        this.customer = item;
-                        this.oldCustomer = { ...item };
+                    selectCustomer: async function (item) {
+                        await this.getCustomer(item, isInvoicesQuotations = true);
+                        this.oldCustomer = { ...this.customer };
                         console.log(this.customer);
-                        localStorage.setItem('customer', JSON.stringify(item))
+                        localStorage.setItem('customer', JSON.stringify(this.customer))
                     },
-                    getCustomer: async function (item) {
+                    getCustomer: async function (item, isInvoicesQuotations = false) {
                         self = this;
-                        await axios.get("/v1/customer/" + item.id)
+                        await axios.get("/v1/customer/" + item.id, {
+                            params: {
+                                isInvoicesQuotations: isInvoicesQuotations,
+                            }
+                        })
                             .then(function (response) {
                                 console.log(response);
                                 for (const [key, value] of Object.entries(response.data)) {
@@ -486,29 +483,6 @@
                     searchCustomer: function () {
                         this.getCustomers(this.searchCustomerWord);
                     },
-                    getInvoices: async function (searchWord = '', offset = 0) {
-                        self = this;
-                        url = '/v1/invoices'
-                        await axios.get(url, {
-                            params: {
-                                search: searchWord,
-                                offset: offset,
-                                moreCheck: true,
-                            }
-                        })
-                            .then(function (response) {
-                                console.log(response);
-                                if (offset == 0) {
-                                    self.offset = 0;
-                                    self.invoices = response.data.invoices;
-                                    self.isMoreInvoices = response.data.isMore;
-                                }
-                                else {
-                                    response.data.invoices.map(invoice => self.invoices.push(invoice));
-                                    self.isMoreInvoices = response.data.isMore;
-                                }
-                            });
-                    },
                     rowClass: function (item, type) {
                         if (!item || type !== 'row') return
                         if (!item.id) return "d-none";
@@ -517,11 +491,6 @@
                         // テスト的に300に
                         this.offset += 300;
                         this.getCustomers(this.searchCustomerWord, this.offset)
-                    },
-                    showMoreInvoices: function () {
-                        // テスト的に300に
-                        this.offsetInvoices += 300;
-                        this.getInvoices('', this.offsetInvoices);
                     },
                     apply: function () {
                         if (this.customerKanaValidate === true) {
@@ -601,8 +570,8 @@
                                 if (value) isUpdate = true;
                             });
                             if (isUpdate) await this.bulkUpsert(this.customer);
-                            this.getCustomers(this.searchCustomerWord);
                         }
+                        this.getCustomers(this.searchCustomerWord);
                         router.push({ path: "?page=index" });
                     }
                 },
@@ -610,7 +579,6 @@
                     if (localStorage.getItem('customer'))
                         this.customer = JSON.parse(localStorage.getItem('customer'));
                     this.getCustomers();
-                    this.getInvoices();
                     document.querySelector('title').textContent = '得意先管理';
                 },
                 router,


### PR DESCRIPTION
関連Issue：得意先ページの編集画面に表示している請求一覧はその得意先に紐づいた請求書を表示する。 #1261

- models.pyのCustomer_Invoices・Quotations間のリレーションを復活
- フロント側で得意先のGET系APIにisInvoicesQuotationsパラメータを乗せれるようにした。
- バック側API。渡ってきたパラメータによってクエリ発行の内部処理を変えるようにした。（InvoicesとQuotationsを返すか否か）