### PR TITLE
一覧テーブルをボーダレス＋ストライプに。主要ページのみ適用。

### DIFF
--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -98,9 +98,9 @@ let daySearch = Vue.component('day-search', {
 // 表示件数コンポーネント
 var indicateCount = Vue.component('indicate-count', {
     template: `
-    <b-row align-h="end">
+    <div>
         <p class="mr-3">表示件数 {{ this.indicateCount }}件</p>
-    </b-row>
+    <div>
     `,
     props: {
         indicateCount: Number,

--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -111,7 +111,7 @@ var indicateCount = Vue.component('indicate-count', {
 Vue.component('invoice-list', {
     template: `
     <div>
-        <b-table responsive hover small id="invoicetable" sort-by="ID" small label="Table Options"
+        <b-table borderless responsive hover small id="invoicetable" sort-by="ID" small label="Table Options"
             :items=invoicesIndicateIndex :sort-by.sync="this.sortByInvoices" :sort-desc.sync="this.sortDesc" :fields="[
         {  key: 'update', label: '' },
         {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
@@ -173,7 +173,7 @@ Vue.component('invoice-list', {
 Vue.component('invoice-list-payment', {
     template: `
     <div>
-        <b-table responsive hover small id="invoicetable" label="Table Options"
+        <b-table borderless responsive hover small id="invoicetable" label="Table Options"
             :items=invoicesIndicateIndex :sort-by.sync="this.sortByInvoices" :sort-desc.sync="this.sortDesc" :fields="[
         {  key: 'update', label: '' },
         {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -92,7 +92,7 @@
                             </b-row>
                             <!-- ヘッダーをクリックするとソートが解除されるバグ解消のために、ソート可能なth以外はクリック無効にしているので注意 -->
                             <b-table responsive hover small id="customertable" sort-by="ID" small label="Table Options"
-                                :items=customersIndicateIndex :sort-by.sync="sortByCustomers" :fields="[
+                                borderless :items=customersIndicateIndex :sort-by.sync="sortByCustomers" :fields="[
                       {  key: 'update', label: '' },
                       {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                       {  key: 'anyNumber', label: 'No.', sortable: true, thClass:'th-any-number' },
@@ -266,7 +266,7 @@
                                     </b-form-group>
                                 </b-col>
                                 <b-col lg>
-                                    <b-table responsive hover small id="invoicetable" label="Table Options"
+                                    <b-table responsive hover small id="invoicetable" label="Table Options" borderless
                                         :items=customer_invoicesFilter sticky-header style="max-height: 500px;" :fields="[
                                             {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                                             {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -267,7 +267,7 @@
                                 </b-col>
                                 <b-col lg>
                                     <b-table responsive hover small id="invoicetable" label="Table Options"
-                                        :items=customer.invoices sticky-header style="max-height: 500px;" :fields="[
+                                        :items=customer_invoicesFilter sticky-header style="max-height: 500px;" :fields="[
                                             {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                                             {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
                                             {  key: 'applyDate', label: '日付', thClass: 'th-apply-date text-center', tdClass: 'text-center', sortable: true },
@@ -600,6 +600,18 @@
                             customers = customers.filter(customer => customer.isFavorite === true);
                         this.customersIndicateCount = customers.length;
                         return customers;
+                    },
+                    customer_invoicesFilter: function () {
+                        const customer = this.customer;
+                        let existCustomerInvoices = [];
+                        if (customer.invoices == undefined)
+                            return [];
+                        customer.invoices.map(invoice => {
+                            if (invoice.isDelete === false) {
+                                existCustomerInvoices.push(invoice);
+                            }
+                        });
+                        return existCustomerInvoices;
                     },
                     // バリデーション
                     customerKanaValidate() {

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -78,15 +78,17 @@
                                     </b-col>
                                 </b-col>
                             </b-row>
-                            <b-row align-h="end">
-                                <p class="mr-3">表示件数 {{customersIndicateCount}}件</p>
-                            </b-row>
-                            <b-row align-h="start">
-                                <router-link to="?page=store">
-                                    <b-button variant="primary" id="new-button" class="mb-3 ml-3"
-                                        @click="CustomerAddRow();">＋新規追加
-                                    </b-button>
-                                </router-link>
+                            <b-row>
+                                <b-col class="text-left">
+                                    <router-link to="?page=store">
+                                        <b-button variant="primary" id="new-button" class="mb-3 ml-3"
+                                            style="margin-left: 0 !important ;" @click="CustomerAddRow();">＋新規追加
+                                        </b-button>
+                                    </router-link>
+                                </b-col>
+                                <b-col class="text-right">
+                                    <p class="mr-3">表示件数 {{customersIndicateCount}}件</p>
+                                </b-col>
                             </b-row>
                             <!-- ヘッダーをクリックするとソートが解除されるバグ解消のために、ソート可能なth以外はクリック無効にしているので注意 -->
                             <b-table responsive hover small id="customertable" sort-by="ID" small label="Table Options"

--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -183,6 +183,15 @@
             width: 100%;
             height: 100%;
         }
+
+        .table>tbody>tr:nth-child(even) {
+            background-color: #ECECEC50;
+        }
+
+        .table tbody tr:hover td,
+        .table tbody tr:hover th {
+            background-color: #ECECEC;
+        }
     </style>
 
 </head>

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -242,9 +242,9 @@
                                                 <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示
                                                 </b-form-checkbox>
                                             </b-row>
-                                            <b-table hover striped small id="customer-table" :items="searchCustomers"
-                                                @row-clicked="customerSelect" label="Table Options"
-                                                :sort-by.sync="this.sortByCustomers" :fields="[
+                                            <b-table borderless hover striped small id="customer-table"
+                                                :items="searchCustomers" @row-clicked="customerSelect"
+                                                label="Table Options" :sort-by.sync="this.sortByCustomers" :fields="[
                                                       {  key: 'anyNumber', label: 'No.' },
                                                       {  key: 'customerName', label: '得意先名' },
                                                 ]">
@@ -329,7 +329,7 @@
                         </b-card>
 
                         <!--  table list & edit -->
-                        <b-table hover caption-top small id="invoice_items_table" primary-key="id" small
+                        <b-table borderless hover caption-top small id="invoice_items_table" primary-key="id" small
                             label="Table Options" :items=invoice.invoice_items :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'rowNum', thClass: 'd-none', tdClass: 'd-none' },
@@ -401,8 +401,8 @@
                                             </b-row>
                                         </b-col>
                                     </b-row>
-                                    <b-table hover striped small sort-by="ID" id="items-table" :items="searchItems"
-                                        @row-clicked="itemSelect" label="Table Options" :fields="[
+                                    <b-table borderless hover striped small sort-by="ID" id="items-table"
+                                        :items="searchItems" @row-clicked="itemSelect" label="Table Options" :fields="[
                                   {  key: 'id', label: 'No.' },
                                   {  key: 'itemName', label: '商品名' },
                                   {  key: 'unit',   label: '単位' },
@@ -662,8 +662,8 @@
             <!-- 入金モーダル -->
             <div>
                 <b-modal size="xl" id="payment-modal" :title="'請求書No. ' + invoice.applyNumber">
-                    <b-table hover striped small sort-by="ID" id="payment-table" :items="invoice.invoice_payments"
-                        label="Table Options" :fields="[
+                    <b-table borderless hover striped small sort-by="ID" id="payment-table"
+                        :items="invoice.invoice_payments" label="Table Options" :fields="[
                               {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                               {  key: 'paymentDate', label: '入金日' },
                               {  key: 'paymentMethod', label: '支払い方法' },

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -166,14 +166,19 @@
                                         </day-search>
                                     </b-col>
                                 </b-row>
-                                <indicate-count :indicate-count="invoicesIndicateCount"></indicate-count>
-                                <b-row align-h="start">
-                                    <router-link to="?page=store">
-                                        <b-button v-if="procName=='normal'" variant="primary" id="new-button"
-                                            class="mb-3 ml-3" @click="InvoiceAddRow();">
-                                            ＋新規追加
-                                        </b-button>
-                                    </router-link>
+                                <b-row>
+                                    <b-col class="text-left">
+                                        <router-link to="?page=store">
+                                            <b-button v-if="procName=='normal'" variant="primary" id="new-button"
+                                                style="margin-left: 0 !important ;" class="mb-3 ml-3"
+                                                @click="InvoiceAddRow();">
+                                                ＋新規追加
+                                            </b-button>
+                                        </router-link>
+                                    </b-col>
+                                    <b-col class="text-right">
+                                        <indicate-count :indicate-count="invoicesIndicateCount"></indicate-count>
+                                    </b-col>
                                 </b-row>
                                 <!-- ヘッダーをクリックするとソートが解除されるバグ解消のために、ソート可能なth以外はクリック無効にしているので注意 -->
                                 <!-- 一覧 -->

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -108,15 +108,17 @@
                                     </b-row>
                                 </b-col>
                             </b-row>
-                            <b-row align-h="end">
-                                <p class="mr-3">表示件数 {{itemsIndicateCount}}件</p>
-                            </b-row>
-                            <b-row align-h="start">
-                                <router-link to="?page=store">
-                                    <b-button variant="primary" id="new-button" class="mb-3 ml-3"
-                                        @click="ItemAddRow();">＋新規追加
-                                    </b-button>
-                                </router-link>
+                            <b-row class="mt-3">
+                                <b-col class="text-left">
+                                    <router-link to="?page=store">
+                                        <b-button variant="primary" id="new-button" class="mb-3 ml-3"
+                                            style="margin-left: 0 !important ;" @click="ItemAddRow();">＋新規追加
+                                        </b-button>
+                                    </router-link>
+                                </b-col>
+                                <b-col class="text-right">
+                                    <p class="mr-3">表示件数 {{itemsIndicateCount}}件</p>
+                                </b-col>
                             </b-row>
                             <b-table responsive hover small id="itemtable" sort-by="ID" small label="Table Options"
                                 :items=itemsIndicateIndex :fields="[

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -121,7 +121,7 @@
                                 </b-col>
                             </b-row>
                             <b-table responsive hover small id="itemtable" sort-by="ID" small label="Table Options"
-                                :items=itemsIndicateIndex :fields="[
+                                borderless :items=itemsIndicateIndex :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'itemCode', label: '商品コード', thClass: 'text-center', tdClass: 'text-right' },

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -29,38 +29,33 @@
                             header-border-variant="light">
                             <b-row>
                                 <b-col sm>
-                                    <b-row>
-                                        <b-col>
-                                            <b-input-group>
-                                                <b-form-input v-model="searchMemoWord" id="searchMemoWord" size="sm"
-                                                    placeholder="🔍　作成日 or 担当者">
-                                                </b-form-input>
-                                                <b-input-group-append>
-                                                    <b-button variant="primary" size="sm" @click="searchMemo">検索
-                                                    </b-button>
-                                                </b-input-group-append>
-                                            </b-input-group>
-                                        </b-col>
-                                    </b-row>
-                                </b-col>
-                                <div class="ml-5"></div>
-                                <b-col sm>
+                                    <b-input-group>
+                                        <b-form-input v-model="searchMemoWord" id="searchMemoWord" size="sm"
+                                            placeholder="🔍　作成日 or 担当者">
+                                        </b-form-input>
+                                        <b-input-group-append>
+                                            <b-button variant="primary" size="sm" @click="searchMemo">検索
+                                            </b-button>
+                                        </b-input-group-append>
+                                    </b-input-group>
                                 </b-col>
                                 <b-col sm>
-                                    <b-row align-h="end">
-                                        <b-form-checkbox class="mr-3" v-model="isShowFavorite">お気に入り</b-form-checkbox>
-                                    </b-row>
+                                </b-col>
+                                <b-col sm class="text-right">
+                                    <b-form-checkbox class="mr-3" v-model="isShowFavorite">お気に入り</b-form-checkbox>
                                 </b-col>
                             </b-row>
-                            <b-row align-h="end">
-                                <p class="mr-3">表示件数 {{ memosIndicateCount }}件</p>
-                            </b-row>
-                            <b-row align-h="start">
-                                <router-link to="?page=store">
-                                    <b-button variant="primary" id="new-button" class="mb-3 ml-3"
-                                        @click="MemoAddRow();">＋新規追加
-                                    </b-button>
-                                </router-link>
+                            <b-row class="mt-3">
+                                <b-col class="text-left">
+                                    <router-link to="?page=store">
+                                        <b-button variant="primary" id="new-button" class="mb-3 ml-3"
+                                            style="margin-left: 0 !important ;" @click="MemoAddRow();">＋新規追加
+                                        </b-button>
+                                    </router-link>
+                                </b-col>
+                                <b-col class="text-right">
+                                    <p class="mr-3">表示件数 {{ memosIndicateCount }}件</p>
+                                </b-col>
                             </b-row>
                             <b-table responsive hover small id="memotable" sort-by="ID" small label="Table Options"
                                 :items=memosIndicateIndex :fields="[

--- a/app/templates/memo.html
+++ b/app/templates/memo.html
@@ -57,8 +57,8 @@
                                     <p class="mr-3">表示件数 {{ memosIndicateCount }}件</p>
                                 </b-col>
                             </b-row>
-                            <b-table responsive hover small id="memotable" sort-by="ID" small label="Table Options"
-                                :items=memosIndicateIndex :fields="[
+                            <b-table borderless responsive hover small id="memotable" sort-by="ID" small
+                                label="Table Options" :items=memosIndicateIndex :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'createdAt', label: '作成日', thClass: 'text-center', tdClass: 'text-center' },

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -190,7 +190,7 @@
                                 </b-col>
                             </b-row>
                             <!-- ヘッダーをクリックするとソートが解除されるバグ解消のために、ソート可能なth以外はクリック無効にしているので注意 -->
-                            <b-table responsive hover small id="quotationtable" label="Table Options"
+                            <b-table borderless responsive hover small id="quotationtable" label="Table Options"
                                 :items=quotationsIndicateIndex :sort-by.sync="this.sortByQuotations"
                                 :sort-desc.sync="this.sortDesc" :fields="[
                           {  key: 'update', label: '' },
@@ -270,7 +270,7 @@
                                                 <b-form-checkbox class="mr-3" v-model="isShowAll">全て表示
                                                 </b-form-checkbox>
                                             </b-row>
-                                            <b-table hover striped small sort-by="ID" id="customer-table"
+                                            <b-table borderless hover striped small sort-by="ID" id="customer-table"
                                                 :items="searchCustomers" @row-clicked="customerSelect"
                                                 label="Table Options" :fields="[
                                   {  key: 'anyNumber', label: 'No.' },
@@ -389,7 +389,7 @@
                         </b-card>
 
                         <!--  table list & edit -->
-                        <b-table hover caption-top small id="quotation_items_table" primary-key="id" small
+                        <b-table borderless hover caption-top small id="quotation_items_table" primary-key="id" small
                             label="Table Options" :items=quotation.quotation_items :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'rowNum', thClass: 'd-none', tdClass: 'd-none' },
@@ -461,8 +461,8 @@
                                             </b-row>
                                         </b-col>
                                     </b-row>
-                                    <b-table hover striped small sort-by="ID" id="items-table" :items="searchItems"
-                                        @row-clicked="itemSelect" label="Table Options" :fields="[
+                                    <b-table borderless hover striped small sort-by="ID" id="items-table"
+                                        :items="searchItems" @row-clicked="itemSelect" label="Table Options" :fields="[
                                   {  key: 'id', label: 'No.' },
                                   {  key: 'itemName', label: '商品名' },
                                   {  key: 'unit',   label: '単位' },

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -177,15 +177,17 @@
                                     </b-col>
                                 </b-col>
                             </b-row>
-                            <b-row align-h="end">
-                                <p class="mr-3">表示件数 {{ quotationsIndicateCount }}件</p>
-                            </b-row>
-                            <b-row align-h="start">
-                                <router-link to="?page=store">
-                                    <b-button variant="primary" id="new-button" class="mb-3 ml-3"
-                                        @click="QuotationAddRow();">＋新規追加
-                                    </b-button>
-                                </router-link>
+                            <b-row>
+                                <b-col class="text-left">
+                                    <router-link to="?page=store">
+                                        <b-button variant="primary" id="new-button" class="mb-3 ml-3"
+                                            style="margin-left: 0 !important ;" @click="QuotationAddRow();">＋新規追加
+                                        </b-button>
+                                    </router-link>
+                                </b-col>
+                                <b-col class="text-right">
+                                    <p class="mr-3">表示件数 {{ quotationsIndicateCount }}件</p>
+                                </b-col>
                             </b-row>
                             <!-- ヘッダーをクリックするとソートが解除されるバグ解消のために、ソート可能なth以外はクリック無効にしているので注意 -->
                             <b-table responsive hover small id="quotationtable" label="Table Options"

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -103,15 +103,16 @@
                 <b-row class="mt-1">
                     <b-col></b-col>
                     <b-col cols="11">
-                        <b-row align-h="start">
-                            <router-link to="?page=store">
-                                <b-button variant="primary" id="new-button" class="mb-3 ml-3" @click="UserAddRow();">
-                                    ＋新規追加
-                                </b-button>
-                            </router-link>
-                        </b-row>
                         <b-card border-variant="white" class="mb-3 text-center" header="ユーザー一覧"
                             header-border-variant="light">
+                            <b-row align-h="start">
+                                <router-link to="?page=store">
+                                    <b-button variant="primary" id="new-button" class="mb-3 ml-3"
+                                        @click="UserAddRow();">
+                                        ＋新規追加
+                                    </b-button>
+                                </router-link>
+                            </b-row>
                             <b-table responsive hover small id="usertable" sort-by="ID" small label="Table Options"
                                 :items=underAdministrator :sort-by.sync="sortByUsers" :fields="[
                           {  key: 'update', label: '' },


### PR DESCRIPTION
関連Issue：b-tableの項目を水色ストライプに戻す #191

得意先・商品・請求・見積・メモの主要ページのみに適用。
その他のページへの適用はこれから。