### PR TITLE
一覧テーブルのボーダレス＋ストライプ。全ページに適用。

### DIFF
--- a/app/templates/achievement.html
+++ b/app/templates/achievement.html
@@ -51,7 +51,7 @@
                   <p class="mr-3"> {{this.year}}年度
                     {{this.year}}年{{this.month}}月～{{this.afterYear}}年{{this.afterMonth}}月</p>
                 </b-row>
-                <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options"
+                <b-table responsive hover small id="invocestable" sort-by="ID" small label="Table Options" borderless
                   :items=mergeAchievements :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'applyDate', label: '当期', thClass: 'text-center', tdClass: 'text-center' },

--- a/app/templates/category.html
+++ b/app/templates/category.html
@@ -53,7 +53,7 @@
                                 </router-link>
                             </b-row>
                             <b-table responsive hover small id="categorytable" sort-by="ID" small label="Table Options"
-                                :items=categories :fields="[
+                                borderless :items=categories :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', label: 'No.', thClass: 'text-center', tdClass: 'text-center', },
                           {  key: 'categoryName', label: 'カテゴリ名', thClass: 'text-center', tdClass: 'text-center', },

--- a/app/templates/head_min.html
+++ b/app/templates/head_min.html
@@ -95,6 +95,14 @@
             background-color: #4f4f4f;
         }
 
+        .table>tbody>tr:nth-child(even) {
+            background-color: #ECECEC50;
+        }
+
+        .table tbody tr:hover td,
+        .table tbody tr:hover th {
+            background-color: #ECECEC;
+        }
     </style>
 
 </head>
@@ -103,29 +111,29 @@
 
     <% block content %>
         <!--- contents here -->
-    <% endblock %>
+        <% endblock %>
 
-    <script>
-        function polling_session() {
-            if (localStorage.getItem('wMode') !== 'tb') return 
-            url = "/is-session"
-            const xhr = new XMLHttpRequest();
-            xhr.open("GET", url, false);
-            xhr.send(null);
-            if (xhr.status == 200) {
-                response = JSON.parse(xhr.responseText);
-                console.log("tb session:", response.session)
-                if (!response.session) {
-                    if(location.pathname !== '/login')
-                    window.location.href = '/login';
+            <script>
+                function polling_session() {
+                    if (localStorage.getItem('wMode') !== 'tb') return
+                    url = "/is-session"
+                    const xhr = new XMLHttpRequest();
+                    xhr.open("GET", url, false);
+                    xhr.send(null);
+                    if (xhr.status == 200) {
+                        response = JSON.parse(xhr.responseText);
+                        console.log("tb session:", response.session)
+                        if (!response.session) {
+                            if (location.pathname !== '/login')
+                                window.location.href = '/login';
+                        }
+                    } else {
+                        console.log("any error");
+                    }
+
                 }
-            } else {
-                console.log("any error");
-            }
-
-        }
-        setInterval(polling_session, 30000)
-    </script>
+                setInterval(polling_session, 30000)
+            </script>
 
 </body>
 

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -85,7 +85,7 @@
                                 <p class="mr-3">表示件数 {{ invoicesIndicateCount }}件</p>
                             </b-row>
                             <b-table responsive hover small id="invoicetable" sort-by="ID" small label="Table Options"
-                                :items=invoicesIndicateIndex :fields="[
+                                borderless :items=invoicesIndicateIndex :fields="[
                           {  key: 'show', label: '' },
                           {  key: 'id', label: 'No.', thClass: 'text-center', },
                           {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
@@ -225,7 +225,7 @@
                         </b-card>
 
                         <!--  table list & edit -->
-                        <b-table hover caption-top small id="invoice_items_table" primary-key="id" small
+                        <b-table hover caption-top small id="invoice_items_table" primary-key="id" small borderless
                             label="Table Options" :items=invoice.invoice_items :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'itemId', label: '商品ID', tdClass:'td-item-id' ,sortable: true},

--- a/app/templates/maker.html
+++ b/app/templates/maker.html
@@ -52,7 +52,7 @@
                                 </router-link>
                             </b-row>
                             <b-table responsive hover small id="makertable" sort-by="ID" small label="Table Options"
-                                :items=makers :fields="[
+                                borderless :items=makers :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', label: 'No.', thClass: 'text-center', tdClass: 'text-center', },
                           {  key: 'makerName', label: 'メーカー名', thClass: 'text-center', tdClass: 'text-center', },

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -85,7 +85,7 @@
                                 <p class="mr-3">表示件数 {{ quotationsIndicateCount }}件</p>
                             </b-row>
                             <b-table responsive hover small id="quotationtable" sort-by="ID" small label="Table Options"
-                                :items=quotationsIndicateIndex :fields="[
+                                borderless :items=quotationsIndicateIndex :fields="[
                           {  key: 'show', label: '' },
                           {  key: 'id', label: 'No.', thClass: 'text-center', },
                           {  key: 'applyNumber', label: '見積番号', thClass: 'text-center', tdClass: 'text-center' },
@@ -223,7 +223,7 @@
                         </b-card>
 
                         <!--  table list & edit -->
-                        <b-table hover caption-top small id="quotation_items_table" primary-key="id" small
+                        <b-table hover caption-top small id="quotation_items_table" primary-key="id" small borderless
                             label="Table Options" :items=quotation.quotation_items :fields="[
                           {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
                           {  key: 'itemId', label: '商品ID', tdClass:'td-item-id' ,sortable: true},

--- a/app/templates/unit.html
+++ b/app/templates/unit.html
@@ -53,7 +53,7 @@
                                 </router-link>
                             </b-row>
                             <b-table responsive hover small id="unittable" sort-by="ID" small label="Table Options"
-                                :items=units :fields="[
+                                borderless :items=units :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'id', label: 'No.', thClass: 'text-center', tdClass: 'text-center', },
                           {  key: 'unitName', label: '単位名', thClass: 'text-center', tdClass: 'text-center', },

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -81,8 +81,8 @@
                 <!-- ログイン履歴一覧モーダル -->
                 <b-modal size="xl" id="login-history-modal">
                     <p>ログイン履歴</p>
-                    <b-table hover striped small sort-by="ID" id="login-history-table" :items="loginHistories"
-                        label="Table Options" :fields="[
+                    <b-table hover striped small sort-by="ID" id="login-history-table" borderless
+                        :items="loginHistories" label="Table Options" :fields="[
                               {  key: 'id', label: 'No.' },
                               {  key: 'userName', label: 'ユーザー名' },
                               {  key: 'modelName', label: '対象' },
@@ -114,7 +114,7 @@
                                 </router-link>
                             </b-row>
                             <b-table responsive hover small id="usertable" sort-by="ID" small label="Table Options"
-                                :items=underAdministrator :sort-by.sync="sortByUsers" :fields="[
+                                borderless :items=underAdministrator :sort-by.sync="sortByUsers" :fields="[
                           {  key: 'update', label: '' },
                           {  key: 'anyNumber', label: 'No.', thClass: 'text-center', },
                           {  key: 'name', label: 'ユーザー名', thClass: 'text-center', },


### PR DESCRIPTION
関連Issue：b-tableの項目を水色ストライプに戻す #191

実績・ユーザー・カテゴリ・メーカー・単位・削除済み請求・削除済み見積ページに適用。