### PR TITLE
合計請求モーダル実装。チェックした請求を配列にまとめるところまで実装。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1120,7 +1120,6 @@
                         this.getInvoices(this.searchInvoiceWord, this.offset);
                     },
                     showMoreInTotalInvoice: function () {
-                        // テスト的に300に
                         this.offsetInTotalInvoice += 300;
                         this.getInvoices(this.searchCustomerWordInTotalInvoice, this.offsetInTotalInvoice, true);
                     },

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -170,7 +170,11 @@
                                               {  key: 'customerName', label: '得意先名' },
                                         ]">
                                     </b-table>
-
+                                    <b-row align-h="end">
+                                        <b-button v-if="isMoreInTotalInvoice" variant="primary" size="sm" class="mr-3"
+                                            @click="showMoreInTotalInvoice">さらに表示
+                                        </b-button>
+                                    </b-row>
                                 </b-modal>
                             </b-row>
                             <b-card border-variant="white" class="mb-3 text-center" :header="headerName"
@@ -791,6 +795,7 @@
                     invoicesInTotalInvoice: [],             //合計請求書専用
                     customerNames: [],                      //合計請求書専用 | 再利用可
                     isMoreInTotalInvoice: false,            //合計請求書専用
+                    offsetInTotalInvoice: 0,                //合計請求書専用
                     fileId: '', //upload用ID
                     dicFiles: [],
                     form: {
@@ -821,6 +826,7 @@
                                 console.log(response);
                                 if (offset == 0) {
                                     self.offset = 0;
+                                    self.offsetInTotalInvoice = 0;
                                     if (isTotalInvoice) {
                                         self.invoicesInTotalInvoice = response.data.invoices;
                                         self.isMoreInTotalInvoice = response.data.isMore;
@@ -1095,6 +1101,11 @@
                         this.offset += 300;
                         this.getInvoices(this.searchInvoiceWord, this.offset);
                     },
+                    showMoreInTotalInvoice: function () {
+                        // テスト的に300に
+                        this.offsetInTotalInvoice += 300;
+                        this.getInvoices(this.searchCustomerWordInTotalInvoice, this.offsetInTotalInvoice, true);
+                    },
                     coutFiles: function () {
                         self = this;
                         axios.get("/count-files/s/upload/invoices")
@@ -1280,6 +1291,7 @@
                         this.searchDayEnd = end;
                     },
                     selectChangeInTotalInvoiceModal() {
+                        this.offsetInTotalInvoice = 0;
                         this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
                     },
                 },

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -157,7 +157,15 @@
                                         @click="$bvModal.show('total-invoice-modal')">合計請求書</b-button>
                                 </b-col>
                                 <b-modal size="xl" id="total-invoice-modal">
-                                    <p>得意先を選択してください</p>
+                                    <b-row>
+                                        <b-col>
+                                            <p>得意先を選択してください</p>
+                                        </b-col>
+                                        <b-col class="text-right mb-3">
+                                            <b-button @click="allCheckedInTotalInvoice">全て選択</b-button>
+                                            <b-button variant="primary" @click="totalInvoice">合計請求</b-button>
+                                        </b-col>
+                                    </b-row>
                                     <b-select v-model="searchCustomerWordInTotalInvoice"
                                         @change="selectChangeInTotalInvoiceModal" :options="customerNames">
                                     </b-select>
@@ -166,9 +174,19 @@
                                     <b-table borderless hover small id="invoice-table" :items="invoicesInTotalInvoice"
                                         :sort-by.sync="this.sortByInvoices" :fields="[
                                               {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
+                                              {  key: 'applyNumber', label: '請求番号' },
+                                              {  key: 'applyDate', label: '日付' },
+                                              {  key: 'customerAnyNumber', label: 'No.' },
                                               {  key: 'title', label: '件名' },
-                                              {  key: 'customerName', label: '得意先名' },
+                                              {  key: 'totalAmount', label: '請求金額' },
+                                              {  key: 'isTotalCheck', label: '' },
                                         ]">
+                                        <template v-slot:cell(isTotalCheck)="data">
+                                            <b-form-checkbox v-model="data.item.isChecked"></b-form-checkbox>
+                                        </template>
+                                        <!-- <template v-slot:cell(totalAmount)="data">
+                                            {{amountCalculation(data.item)|nf}}
+                                        </template> -->
                                     </b-table>
                                     <b-row align-h="end">
                                         <b-button v-if="isMoreInTotalInvoice" variant="primary" size="sm" class="mr-3"
@@ -1278,6 +1296,25 @@
                         interval = row > 1 ? 0 : 5;
                         return "height: " + (26 * row + interval) + "px";
                     },
+                    selectChangeInTotalInvoiceModal() {
+                        this.offsetInTotalInvoice = 0;
+                        this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
+                    },
+                    allCheckedInTotalInvoice() {
+                        this.invoicesInTotalInvoice.map(invoice => {
+                            this.$set(invoice, 'isChecked', true);
+                        });
+                    },
+                    totalInvoice() {
+                        let checkedInvoices = [];
+                        this.invoicesInTotalInvoice.map(invoice => {
+                            if (invoice.isChecked) {
+                                checkedInvoices.push(invoice);
+                            }
+                        });
+                        // ↓最終結果。これをPDF側に渡す？
+                        console.log(checkedInvoices);
+                    },
                     // ----- 子コンポーネントからの値 -----
                     updateInvoices(invoices, searchInvoiceWord, isMore) {
                         this.invoices = invoices;
@@ -1289,10 +1326,6 @@
                     },
                     updateDayEnd(end) {
                         this.searchDayEnd = end;
-                    },
-                    selectChangeInTotalInvoiceModal() {
-                        this.offsetInTotalInvoice = 0;
-                        this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
                     },
                 },
                 mounted: function () {

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -151,6 +151,28 @@
                                     <sc-menu class="mb-3" v-if="modeName!='mw'"></sc-menu>
                                 </b-col>
                             </b-row>
+                            <b-row>
+                                <b-col class="text-right">
+                                    <b-button size="sm" variant="primary" class="mb-3"
+                                        @click="$bvModal.show('total-invoice-modal')">合計請求書</b-button>
+                                </b-col>
+                                <b-modal size="xl" id="total-invoice-modal">
+                                    <p>得意先を選択してください</p>
+                                    <b-select v-model="searchCustomerWordInTotalInvoice"
+                                        @change="selectChangeInTotalInvoiceModal" :options="customerNames">
+                                    </b-select>
+                                    <b-row align-h="end">
+                                    </b-row>
+                                    <b-table borderless hover small id="invoice-table" :items="invoicesInTotalInvoice"
+                                        :sort-by.sync="this.sortByInvoices" :fields="[
+                                              {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
+                                              {  key: 'title', label: '件名' },
+                                              {  key: 'customerName', label: '得意先名' },
+                                        ]">
+                                    </b-table>
+
+                                </b-modal>
+                            </b-row>
                             <b-card border-variant="white" class="mb-3 text-center" :header="headerName"
                                 header-border-variant="light">
                                 <b-row>
@@ -765,6 +787,10 @@
                     isShowAll: false,        // trueの時、customer.isHide=falseのもののみindexに表示
                     isShowFavorite: false,
                     isMore: false,
+                    searchCustomerWordInTotalInvoice: '',   //合計請求書専用
+                    invoicesInTotalInvoice: [],             //合計請求書専用
+                    customerNames: [],                      //合計請求書専用 | 再利用可
+                    isMoreInTotalInvoice: false,            //合計請求書専用
                     fileId: '', //upload用ID
                     dicFiles: [],
                     form: {
@@ -781,7 +807,7 @@
                 },
                 methods: {
                     // ---Invoices---
-                    getInvoices: async function (searchWord = '', offset = 0) {
+                    getInvoices: async function (searchWord = '', offset = 0, isTotalInvoice = false) {
                         self = this;
                         url = '/v1/invoices'
                         await axios.get(url, {
@@ -795,10 +821,20 @@
                                 console.log(response);
                                 if (offset == 0) {
                                     self.offset = 0;
+                                    if (isTotalInvoice) {
+                                        self.invoicesInTotalInvoice = response.data.invoices;
+                                        self.isMoreInTotalInvoice = response.data.isMore;
+                                        return;
+                                    }
                                     self.invoices = response.data.invoices;
                                     self.isMore = response.data.isMore;
                                 }
                                 else {
+                                    if (isTotalInvoice) {
+                                        response.data.invoices.map(invoice => self.invoicesInTotalInvoice.push(invoice));
+                                        self.isMoreInTotalInvoice = response.data.isMore;
+                                        return;
+                                    }
                                     response.data.invoices.map(invoice => self.invoices.push(invoice));
                                     self.isMore = response.data.isMore;
                                 }
@@ -997,6 +1033,11 @@
                             .then(function (response) {
                                 console.log(response);
                                 self.customers = response.data;
+                                let customerNames = [];
+                                self.customers.map(customer => {
+                                    customerNames.push(customer.customerName);
+                                    self.customerNames = [...customerNames];
+                                })
                             });
                     },
                     getCustomer: async function (item) {
@@ -1237,6 +1278,9 @@
                     },
                     updateDayEnd(end) {
                         this.searchDayEnd = end;
+                    },
+                    selectChangeInTotalInvoiceModal() {
+                        this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
                     },
                 },
                 mounted: function () {


### PR DESCRIPTION
関連Issue：合計請求機能の実装（フロント） #1276

- 合計請求モーダル作成。
- 得意先を選択するとそれに紐づいた請求一覧が表示されるようにした。
- limitを300件にして、追加分を都度呼べるようにした。
- 「全て選択」ボタンで請求のチェックボックスを全選択できるようにした。
- チェックした請求を配列に纏め、参照できるところまで実装。