### PR TITLE
請求・見積書印刷時のロゴの位置を修正。

### DIFF
--- a/app/static/component/def-pdf.js
+++ b/app/static/component/def-pdf.js
@@ -162,7 +162,7 @@ function getPdfData(h, sum) {
                     ["('" + h.baseImagePath + "',0,0, 210*mm,295*mm,mask='auto')"]
                 ],
                 "drawImages": [
-                    ["('" + h.logoPath + "', 350,730," + h.logoWidth + "," + h.logoHeight + ",mask='auto')"]
+                    ["('" + h.logoPath + "', 350,760," + h.logoWidth + "," + h.logoHeight + ",mask='auto')"]
                 ]
             },
             "body": {


### PR DESCRIPTION
関連Issue：ロゴは社名に被らないようにする。 #1283

とりあえずサイズ４０の時に社名に被らないようにしてみた。
細かい要望聞きながら修正した方が良い気がするので、一旦これでプルリク。