### PR TITLE
請求書印刷時に支払期限がnullだった場合、「Invalid date」と表示されてしまうのを修正。

### DIFF
--- a/app/static/component/def-pdf.js
+++ b/app/static/component/def-pdf.js
@@ -47,7 +47,7 @@ function getPdfDataInvoice(mode, invoice, setting, sumInvoice, customer, docClas
     sum.tax = sumInvoice.taxAmount;
     sum.total = sumInvoice.priceIncludingTax
     h.memo = nvl(invoice.memo, '');
-    h.deadLine = moment(nvl(invoice.deadLine, '')).format("YYYY年MM月DD日");
+    h.deadLine = invoice.deadLine ? moment(nvl(invoice.deadLine, '')).format("YYYY年MM月DD日") : '';
     h.payee = nvl(setting.payee, '');
     h.accountHolderKana = nvl(setting.accountHolderKana);
     h.accountHolder = nvl(setting.accountHolder);


### PR DESCRIPTION
関連Issue：請求書印刷時の支払期限項目。データがnullの時に「Invalid date」となる。 #1285