### PR TITLE
e2e: 請求書入力で未保存データがあった場合のテスト Add/e2e update alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ app/static/asset/stamp/*
 !NotImage.png
 app/static/component/customize/
 *.mp4
+tests_e2e/cypress/screenshots/

--- a/tests_e2e/cypress/e2e/updateAlert.cy.js
+++ b/tests_e2e/cypress/e2e/updateAlert.cy.js
@@ -1,0 +1,36 @@
+describe('update alert test', () => {
+    it('update invoice alert test', () => {
+
+        cy.visit('http://localhost:5010/login')
+        cy.get('#userId').type('tanaka_taro')
+        cy.get('#password').type('password')
+        cy.get('.btn').click()
+
+        //to invoice page
+        cy.visit('http://localhost:5010/invoice-page#/')
+
+        //一覧で最初の明細行を選択
+        cy.get(':nth-child(1) > [aria-colindex="1"] > a > .btn').click()
+        //詳細入力でヘッダーの任意の項目を更新する
+        cy.get('#honorificTitle').type('テストです{enter}')
+        //戻るボタンをクリック
+        cy.get('.col > .btn').click()
+        //モーダル表示、保存しないで戻るをクリック
+        cy.get('.modal-footer > .btn-danger').should('have.text', '保存しないで戻る').click()
+
+        //一覧で最初の明細行を選択
+        cy.get(':nth-child(1) > [aria-colindex="1"] > a > .btn').click()
+        //詳細入力の明細行1行目を更新
+        cy.get('#invoice_items_table').find('tr').eq(1).find('td').eq(3).type('{selectall}{backspace}AA') //free item
+        cy.get('#invoice_items_table').find('tr').eq(1).find('td').eq(4).type('{selectall}{backspace}ノートPC') //contents
+        cy.get('#invoice_items_table').find('tr').eq(1).find('td').eq(5).type('{selectall}{backspace}05') //qty
+        cy.get('#invoice_items_table').find('tr').eq(1).find('td').eq(6).find('select').select('台') // 
+        cy.get('#invoice_items_table').find('tr').eq(1).find('td').eq(7).clear().type('{selectall}{backspace}98000') //cost 
+        //戻るボタンをクリック
+        cy.get('.col > .btn').click()
+        //モーダル表示、保存しないで戻るをクリック
+        cy.get('.modal-footer > .btn-danger').should('have.text', '保存しないで戻る').click()
+    
+
+    })
+})


### PR DESCRIPTION
請求書入力で2つのパターンをテストした。

請求書ヘッダーデータの修正　->　未保存アラートは期待どおりの動き
明細行データの修正　-> 未保存アラート出ず。

テスト動画はISSUEのコメント欄にアップする。