### PR TITLE
amountInTotalInvoice()の計算ロジックの間違い修正

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1480,24 +1480,17 @@
                         let totalBillings = [];
                         invoices.map(invoice => {
                             let subTotals = [];
-                            if (invoice.isChecked && invoice.isTaxExp) {
-                                invoice.invoice_items.map(item => {
-                                    const beforeTotal = parseInt(item.count * Math.round(item.price));
-                                    const subTotal = parseInt(beforeTotal * (1 + invoice.tax / 100));
-                                    subTotals.push(subTotal);
-                                });
-                            }
-                            else if (invoice.isChecked && invoice.isTaxExp == false) {
-                                invoice.invoice_items.map(item => {
-                                    const subTotal = parseInt(item.count * Math.round(item.price));
-                                    subTotals.push(subTotal);
-                                });
-                            }
                             if (invoice.isChecked) {
+                                invoice.invoice_items.map(item => {
+                                    subTotals.push(parseInt(item.count * Math.round(item.price)));
+                                });
                                 const total = subTotals.reduce(function (sum, element) {
                                     return sum + element;
                                 }, 0);
-                                totalBillings.push(total);
+                                if (invoice.isTaxExp)
+                                    totalBillings.push(parseInt(total * (1 + invoice.tax / 100)));
+                                else
+                                    totalBillings.push(parseInt(total));
                             }
                         });
                         return totalBillings;


### PR DESCRIPTION
関連PR：合計請求モーダル内でチェックされた請求書の請求総額がリスト化されるようにした。 #1292

上記のプルリクで請求総額のリスト化を行ったが、
税金処理は商品単位ではなく請求書単位で行うので、請求書単位での課税処理に修正。