### PR TITLE
合計請求モーダルの全選択バグ修正

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1310,8 +1310,10 @@
                         this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
                     },
                     allCheckedInTotalInvoice() {
-                        this.invoicesInTotalInvoice.map(invoice => {
-                            this.$set(invoice, 'isChecked', true);
+                        const indicateInvoices = [...this.invoicesIndicateIndexInTotalInvoice];
+                        indicateInvoices.map(invoice => {
+                            const selectInvoice = this.invoicesInTotalInvoice.find(element => element.id === invoice.id);
+                            this.$set(selectInvoice, 'isChecked', true);
                         });
                     },
                     totalInvoiceOpen() {


### PR DESCRIPTION
関連Issue：合計請求モーダルの「全て選択」で、選択できないはずの請求書がチェックされる #1303