### PR TITLE
ディフォルトレイアウト修正残分　#1192

### DIFF
--- a/app/pdfmaker/app/pdf_maker.py
+++ b/app/pdfmaker/app/pdf_maker.py
@@ -65,6 +65,8 @@ class NumberedCanvas(canvas.Canvas):
         canvas.Canvas.save(self)
 
     def draw_page_number(self, page_count):
+        return
+        #print page number 
         self.setFont("Helvetica", 7)
         if page_count > 1 :
             self.drawRightString(200*mm, 5*mm,

--- a/app/static/component/def-pdf.js
+++ b/app/static/component/def-pdf.js
@@ -225,7 +225,7 @@ function getPdfData(h, sum) {
                     // copy 
                     h.docClass == 'copy' ? { "pos_xy": ["E", "(95*mm,220*mm)"], "table": [[["P", "(控え)", "md_l_b"]]], "col_widths": ["E", "(30*mm)"] } : {},
                     // total area 
-                    h.mode == 'receipt' ? {} : { "pos_xy": ["E", "(40*mm,218*mm)"], "table": [[["P", h.title, "sm_l"]]], "col_widths": ["E", "(70*mm)"] },
+                    h.mode == 'receipt' ? {} : { "pos_xy": ["E", "(40*mm,218*mm)"], "table": [[["P", h.title, "sm_l"]]], "col_widths": ["E", "(110*mm)"] },
                     h.mode == 'receipt' ? { "pos_xy": ["E", "(45*mm,209*mm)"], "table": [[["PF", sum.total, "md_c_b", "￥{:,}-"]]], "col_widths": ["E", "(50*mm)"] } :
                         { "pos_xy": ["E", "(45*mm,208*mm)"], "table": [[["PF", sum.total, "md_c_b", "￥{:,}-"]]], "col_widths": ["E", "(50*mm)"] },
                     h.mode == 'receipt' ? { "pos_xy": ["E", "(33*mm,193*mm)"], "table": [[["PF", sum.amount, "sm_r", "{:,}"]]], "col_widths": ["E", "(20*mm)"] } :{},


### PR DESCRIPTION
・タイトルは25行とした。

・ページ番号は明細行があふれたときで次ページにデータがあるときにしか出ないようになっていたが、そのロジックを一旦コメントアウトした。また復活する場合はいつでももとに戻せる。

・意図的にdevelopブランチにプルリクした。