### PR TITLE
保存前に見積書を印刷しようとするとcustomer周りでundefinedエラーになるので修正。

### DIFF
--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -744,6 +744,7 @@
                     oldQuotation: [],
                     quotationItem: [],            //選択中のquotationItem
                     customers: [],
+                    customer: [],
                     items: [],
                     units: [],
                     categories: [],


### PR DESCRIPTION
関連Issue：見積印刷時に得意先の郵便番号まわりで怒られる #1309

見積書を保存する前に見積書印刷ボタンを押下するとundefinedエラーで何もアクションが起こらない状態になっていた。
参照先が無いのが原因でエラーが出ていたので、参照先を追加してあげた。