### PR TITLE
未入金チェックページから合計請求書ボタンを削除

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -157,7 +157,8 @@
                             </b-row>
                             <b-row>
                                 <b-col class="text-right">
-                                    <b-button size="sm" variant="primary" class="mb-3" @click="totalInvoiceOpen();">
+                                    <b-button v-if="procName=='normal'" size="sm" variant="primary" class="mb-3"
+                                        @click="totalInvoiceOpen();">
                                         合計請求書
                                     </b-button>
                                 </b-col>


### PR DESCRIPTION
関連Issue：未入金チェックページでは合計請求書機能はいらないので、ボタンを消す。 #1324

