### PR TITLE
設定・請求・見積編集画面に複数メモ切替・入力機能追加（フロント側）

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -319,10 +319,55 @@
                                     </b-form-group>
                                 </b-col>
                                 <b-col xl>
-                                    <b-form-group label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ" label-align="right">
+                                    <b-form-group v-if="!setting.isMemoQuadrupleIndicate" label-cols="2"
+                                        label-cols-lg="2" label-size="sm" label="メモ" label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="invoice.memo" size="sm" rows="3">
                                         </b-form-textarea>
+                                    </b-form-group>
+                                    <b-form-group v-else label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
+                                        label-for="メモ" label-align="right">
+                                        <b-card no-body style="padding: 15px 10px 0 0;">
+                                            <b-row>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel1" label-for="memo1"
+                                                        label-align="right">
+                                                        <b-form-input v-model="invoice.memo1" id="memo1" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel2" label-for="memo2"
+                                                        label-align="right">
+                                                        <b-form-input v-model="invoice.memo2" id="memo2" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                            </b-row>
+                                            <b-row>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel3" label-for="memo3"
+                                                        label-align="right">
+                                                        <b-form-input v-model="invoice.memo3" id="memo3" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel4" label-for="memo4"
+                                                        label-align="right">
+                                                        <b-form-input v-model="invoice.memo4" id="memo4" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                            </b-row>
+                                        </b-card>
                                     </b-form-group>
                                 </b-col>
                             </b-row>

--- a/app/templates/invoice_dust.html
+++ b/app/templates/invoice_dust.html
@@ -197,7 +197,7 @@
                                     </b-form-group>
                                 </b-col>
                             </b-row>
-                            <b-row>
+                            <b-row v-if="!setting.isMemoQuadrupleIndicate">
                                 <b-col sm>
                                 </b-col>
                                 <b-col sm>
@@ -207,6 +207,36 @@
                                     </b-form-group>
                                 </b-col>
                             </b-row>
+                            <div v-else>
+                                <b-row>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel1" label-for="memo1" label-align="right">
+                                            <p class="text-left pl-2" id="memo1">{{invoice.memo1}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel2" label-for="memo2" label-align="right">
+                                            <p class="text-left pl-2" id="memo2">{{invoice.memo2}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                </b-row>
+                                <b-row>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel3" label-for="memo3" label-align="right">
+                                            <p class="text-left pl-2" id="memo3">{{invoice.memo3}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel4" label-for="memo4" label-align="right">
+                                            <p class="text-left pl-2" id="memo4">{{invoice.memo4}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                </b-row>
+                            </div>
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -379,10 +379,55 @@
                                     </b-form-group>
                                 </b-col>
                                 <b-col xl>
-                                    <b-form-group label-cols="2" label-cols-xl="2" label-size="sm" label="メモ"
-                                        label-for="メモ" label-align="right">
+                                    <b-form-group v-if="!setting.isMemoQuadrupleIndicate" label-cols="2"
+                                        label-cols-lg="2" label-size="sm" label="メモ" label-for="メモ" label-align="right">
                                         <b-form-textarea v-model="quotation.memo" size="sm" rows="3">
                                         </b-form-textarea>
+                                    </b-form-group>
+                                    <b-form-group v-else label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
+                                        label-for="メモ" label-align="right">
+                                        <b-card no-body style="padding: 15px 10px 0 0;">
+                                            <b-row>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel1" label-for="memo1"
+                                                        label-align="right">
+                                                        <b-form-input v-model="quotation.memo1" id="memo1" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel2" label-for="memo2"
+                                                        label-align="right">
+                                                        <b-form-input v-model="quotation.memo2" id="memo2" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                            </b-row>
+                                            <b-row>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel3" label-for="memo3"
+                                                        label-align="right">
+                                                        <b-form-input v-model="quotation.memo3" id="memo3" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                                <b-col>
+                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                        :label="setting.memoLabel4" label-for="memo4"
+                                                        label-align="right">
+                                                        <b-form-input v-model="quotation.memo4" id="memo4" size="sm"
+                                                            autocomplete="off">
+                                                        </b-form-input>
+                                                    </b-form-group>
+                                                </b-col>
+                                            </b-row>
+                                        </b-card>
                                     </b-form-group>
                                 </b-col>
                             </b-row>
@@ -749,6 +794,7 @@
                     units: [],
                     categories: [],
                     makers: [],
+                    setting: [],
                     expiryOptions: ['2週間以内', '1ヶ月以内', '2ヶ月以内',],
                     dayOfDeliveryOptions: ['発注後1週間以内', '発注後2週間以内', '発注後1ヶ月以内', '応相談',],
                     termOfSaleOptions: ['御社決済条件にて', '代金引換', '納品後2週間以内に決済', '納品後翌月末までに決済', '応相談',],

--- a/app/templates/quotation_dust.html
+++ b/app/templates/quotation_dust.html
@@ -195,7 +195,7 @@
                                     </b-form-group>
                                 </b-col>
                             </b-row>
-                            <b-row>
+                            <b-row v-if="!setting.isMemoQuadrupleIndicate">
                                 <b-col sm>
                                 </b-col>
                                 <b-col sm>
@@ -205,6 +205,36 @@
                                     </b-form-group>
                                 </b-col>
                             </b-row>
+                            <div v-else>
+                                <b-row>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel1" label-for="memo1" label-align="right">
+                                            <p class="text-left pl-2" id="memo1">{{quotation.memo1}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel2" label-for="memo2" label-align="right">
+                                            <p class="text-left pl-2" id="memo2">{{quotation.memo2}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                </b-row>
+                                <b-row>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel3" label-for="memo3" label-align="right">
+                                            <p class="text-left pl-2" id="memo3">{{quotation.memo3}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                    <b-col sm>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm"
+                                            :label="setting.memoLabel4" label-for="memo4" label-align="right">
+                                            <p class="text-left pl-2" id="memo4">{{quotation.memo4}}</p>
+                                        </b-form-group>
+                                    </b-col>
+                                </b-row>
+                            </div>
                             <b-row>
                                 <b-col sm>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="件名"

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -286,6 +286,52 @@
                                     </b-form-group>
                                 </b-col>
                             </b-row>
+                            <b-row>
+                                <b-col sm>
+                                    請求書・見積書のメモラベル変更
+                                </b-col>
+                            </b-row>
+                            <b-row>
+                                <b-col sm>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ラベル１"
+                                        label-for="memoLabel1" label-align="right">
+                                        <b-form-input v-model="setting.memoLabel1" id="memoLabel1" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
+                                </b-col>
+                                <b-col sm>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ラベル２"
+                                        label-for="memoLabel2" label-align="right">
+                                        <b-form-input v-model="setting.memoLabel2" id="memoLabel2" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
+                                </b-col>
+                            </b-row>
+                            <b-row>
+                                <b-col sm>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ラベル３"
+                                        label-for="memoLabel3" label-align="right">
+                                        <b-form-input v-model="setting.memoLabel3" id="memoLabel3" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
+                                </b-col>
+                                <b-col sm>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="ラベル４"
+                                        label-for="memoLabel4" label-align="right">
+                                        <b-form-input v-model="setting.memoLabel4" id="memoLabel4" size="sm">
+                                        </b-form-input>
+                                    </b-form-group>
+                                </b-col>
+                            </b-row>
+                            <b-row>
+                                <b-col sm>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ欄切替"
+                                        label-for="isMemoQuadrupleIndicate" label-align="right">
+                                        <b-form-checkbox v-model="setting.isMemoQuadrupleIndicate"></b-form-checkbox>
+                                    </b-form-group>
+                                </b-col>
+                                <b-col sm></b-col>
+                            </b-row>
                         </b-card>
                     </b-col>
                     <b-col></b-col>


### PR DESCRIPTION
関連Issue：請求・見積書の編集ページのメモ欄は通常の入力欄か入力欄４つか選べるようにする。 #1328

- 請求・見積編集ページにメモ欄切替機能・メモ複数入力機能を追加。
- 削除済み請求・見積ページにメモ欄切替機能を追加。
- 設定ページでメモ欄切替・複数メモ欄ラベル編集機能を追加。