### PR TITLE
請求・見積の得意先検索対象を任意番号に変更。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1411,7 +1411,7 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
-                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord) ||
+                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.anyNumber)?.includes(this.searchCustomerWord) ||
                             String(customer.customerKana)?.includes(this.searchCustomerWord)));
                         return customers;
                     },

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -1342,7 +1342,7 @@
                             customers = customers.filter(customer => customer.isHide === false);
                         if (this.isShowFavorite === true)
                             customers = customers.filter(customer => customer.isFavorite === true);
-                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord) ||
+                        customers = customers.filter(customer => (customer.customerName?.includes(this.searchCustomerWord) || String(customer.anyNumber)?.includes(this.searchCustomerWord) ||
                             String(customer.customerKana)?.includes(this.searchCustomerWord)));
                         return customers;
                     },


### PR DESCRIPTION
関連Issue：請求・見積ページの得意先検索での検索対象を得意先任意番号にする。 #1337

フィルタリング対象をidからcustomer.anyNumberに変更。