### PR TITLE
メモ欄４つ表示時のレイアウトを修正。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -326,16 +326,16 @@
                                     </b-form-group>
                                     <div v-else>
                                         <b-row>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel1" label-for="memo1" label-align="right">
                                                     <b-form-input v-model="invoice.memo1" id="memo1" size="sm"
                                                         autocomplete="off">
                                                     </b-form-input>
                                                 </b-form-group>
                                             </b-col>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel2" label-for="memo2" label-align="right">
                                                     <b-form-input v-model="invoice.memo2" id="memo2" size="sm"
                                                         autocomplete="off">
@@ -344,16 +344,16 @@
                                             </b-col>
                                         </b-row>
                                         <b-row>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel3" label-for="memo3" label-align="right">
                                                     <b-form-input v-model="invoice.memo3" id="memo3" size="sm"
                                                         autocomplete="off">
                                                     </b-form-input>
                                                 </b-form-group>
                                             </b-col>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel4" label-for="memo4" label-align="right">
                                                     <b-form-input v-model="invoice.memo4" id="memo4" size="sm"
                                                         autocomplete="off">

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -324,51 +324,44 @@
                                         <b-form-textarea v-model="invoice.memo" size="sm" rows="3">
                                         </b-form-textarea>
                                     </b-form-group>
-                                    <b-form-group v-else label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ" label-align="right">
-                                        <b-card no-body style="padding: 15px 10px 0 0;">
-                                            <b-row>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel1" label-for="memo1"
-                                                        label-align="right">
-                                                        <b-form-input v-model="invoice.memo1" id="memo1" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel2" label-for="memo2"
-                                                        label-align="right">
-                                                        <b-form-input v-model="invoice.memo2" id="memo2" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                            </b-row>
-                                            <b-row>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel3" label-for="memo3"
-                                                        label-align="right">
-                                                        <b-form-input v-model="invoice.memo3" id="memo3" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel4" label-for="memo4"
-                                                        label-align="right">
-                                                        <b-form-input v-model="invoice.memo4" id="memo4" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                            </b-row>
-                                        </b-card>
-                                    </b-form-group>
+                                    <div v-else>
+                                        <b-row>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel1" label-for="memo1" label-align="right">
+                                                    <b-form-input v-model="invoice.memo1" id="memo1" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel2" label-for="memo2" label-align="right">
+                                                    <b-form-input v-model="invoice.memo2" id="memo2" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel3" label-for="memo3" label-align="right">
+                                                    <b-form-input v-model="invoice.memo3" id="memo3" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel4" label-for="memo4" label-align="right">
+                                                    <b-form-input v-model="invoice.memo4" id="memo4" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                        </b-row>
+                                    </div>
                                 </b-col>
                             </b-row>
                         </b-card>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -384,51 +384,44 @@
                                         <b-form-textarea v-model="quotation.memo" size="sm" rows="3">
                                         </b-form-textarea>
                                     </b-form-group>
-                                    <b-form-group v-else label-cols="2" label-cols-lg="2" label-size="sm" label="メモ"
-                                        label-for="メモ" label-align="right">
-                                        <b-card no-body style="padding: 15px 10px 0 0;">
-                                            <b-row>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel1" label-for="memo1"
-                                                        label-align="right">
-                                                        <b-form-input v-model="quotation.memo1" id="memo1" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel2" label-for="memo2"
-                                                        label-align="right">
-                                                        <b-form-input v-model="quotation.memo2" id="memo2" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                            </b-row>
-                                            <b-row>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel3" label-for="memo3"
-                                                        label-align="right">
-                                                        <b-form-input v-model="quotation.memo3" id="memo3" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                                <b-col>
-                                                    <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
-                                                        :label="setting.memoLabel4" label-for="memo4"
-                                                        label-align="right">
-                                                        <b-form-input v-model="quotation.memo4" id="memo4" size="sm"
-                                                            autocomplete="off">
-                                                        </b-form-input>
-                                                    </b-form-group>
-                                                </b-col>
-                                            </b-row>
-                                        </b-card>
-                                    </b-form-group>
+                                    <div v-else>
+                                        <b-row>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel1" label-for="memo1" label-align="right">
+                                                    <b-form-input v-model="quotation.memo1" id="memo1" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel2" label-for="memo2" label-align="right">
+                                                    <b-form-input v-model="quotation.memo2" id="memo2" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                        </b-row>
+                                        <b-row>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel3" label-for="memo3" label-align="right">
+                                                    <b-form-input v-model="quotation.memo3" id="memo3" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                            <b-col>
+                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                                    :label="setting.memoLabel4" label-for="memo4" label-align="right">
+                                                    <b-form-input v-model="quotation.memo4" id="memo4" size="sm"
+                                                        autocomplete="off">
+                                                    </b-form-input>
+                                                </b-form-group>
+                                            </b-col>
+                                        </b-row>
+                                    </div>
                                 </b-col>
                             </b-row>
                         </b-card>

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -386,16 +386,16 @@
                                     </b-form-group>
                                     <div v-else>
                                         <b-row>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel1" label-for="memo1" label-align="right">
                                                     <b-form-input v-model="quotation.memo1" id="memo1" size="sm"
                                                         autocomplete="off">
                                                     </b-form-input>
                                                 </b-form-group>
                                             </b-col>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel2" label-for="memo2" label-align="right">
                                                     <b-form-input v-model="quotation.memo2" id="memo2" size="sm"
                                                         autocomplete="off">
@@ -404,16 +404,16 @@
                                             </b-col>
                                         </b-row>
                                         <b-row>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel3" label-for="memo3" label-align="right">
                                                     <b-form-input v-model="quotation.memo3" id="memo3" size="sm"
                                                         autocomplete="off">
                                                     </b-form-input>
                                                 </b-form-group>
                                             </b-col>
-                                            <b-col>
-                                                <b-form-group label-cols="4" label-cols-lg="4" label-size="sm"
+                                            <b-col xl>
+                                                <b-form-group label-cols="2" label-cols-xl="4" label-size="sm"
                                                     :label="setting.memoLabel4" label-for="memo4" label-align="right">
                                                     <b-form-input v-model="quotation.memo4" id="memo4" size="sm"
                                                         autocomplete="off">


### PR DESCRIPTION
関連Issue：請求・見積編集ページの複数メモ入力欄は枠を外す（普通に並べる）。 #1333