### PR TITLE
isCustomerでPDF前処理構造体にcustomerを入れる。トータル表示のリファクタリング

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -212,9 +212,9 @@
                                             @click="showMoreInTotalInvoice">さらに表示
                                         </b-button>
                                     </b-row>
-                                    請求総額：{{amountInTotalInvoice}}
-                                    本体価格：{{basePriceInTotalInvoice}}
-                                    消費税額：{{taxInTotalInvoice}}
+                                    請求総額：{{eachTotal.billings}}
+                                    本体価格：{{eachTotal.basePrices}}
+                                    消費税額：{{eachTotal.taxies}}
                                     <template #modal-footer>
                                         <button v-b-modal.modal-close_visit class="btn btn-secondary m-1"
                                             @click="$bvModal.hide('total-invoice-modal')">閉じる</button>
@@ -907,7 +907,7 @@
                 },
                 methods: {
                     // ---Invoices---
-                    getInvoices: async function (searchWord = '', offset = 0, isTotalInvoice = false) {
+                    getInvoices: async function (searchWord = '', offset = 0, isTotalInvoice = false, isCustomer = false) {
                         self = this;
                         url = '/v1/invoices'
                         await axios.get(url, {
@@ -915,6 +915,7 @@
                                 search: searchWord,
                                 offset: offset,
                                 moreCheck: true,
+                                isCustomer: isCustomer
                             }
                         })
                             .then(function (response) {
@@ -1375,7 +1376,7 @@
                     },
                     searchInTotalInvoiceModal() {
                         this.offsetInTotalInvoice = 0;
-                        this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true);
+                        this.getInvoices(this.searchCustomerWordInTotalInvoice, 0, true, true);
                     },
                     allCheckedInTotalInvoice() {
                         const indicateInvoices = [...this.invoicesIndicateIndexInTotalInvoice];
@@ -1392,12 +1393,11 @@
                     totalInvoiceOpen() {
                         this.$refs['total-invoice-modal'].show();
                         if (!!this.searchCustomerWordInTotalInvoice)
-                            this.getInvoices(this.searchCustomerWordInTotalInvoice, this.offsetInTotalInvoice, true);
+                            //顧客情報も合わせて読む isCustomer=true
+                            this.getInvoices(this.searchCustomerWordInTotalInvoice, this.offsetInTotalInvoice, true, true);
                     },
                     totalInvoice() {
-                        //let checkedInvoices = [];
                         let checkedInvoices = [];
-                        let checkedCustomers = [];
                         let customer = {};
                         let prePdfToalInoices = [];
                         let customerIds = [];
@@ -1411,9 +1411,8 @@
                                     checkedInvoices.push([]);
                                     ix = customerIds.length - 1
                                 }
-                                //console.log("ix:",ix,customerIds)
                                 checkedInvoices[ix].push(invoice);
-                                checkedCustomers[ix] = this.customers.find(c => c.id == invoice.customerId);
+                                //checkedCustomers[ix] = this.customers.find(c => c.id == invoice.customerId);
                             }
                         });
                         //console.log(checkedInvoices,checkedCustomers)
@@ -1450,7 +1449,6 @@
                             });
                             pt = {
                                 invoices: checkedInvoices[i],
-                                customer: checkedCustomers[i],
                                 totalBillings: totalBillings,
                                 basePrices: basePrices,
                                 taxies: taxies
@@ -1618,50 +1616,10 @@
                     },
                     // 合計モーダル内
                     // 選択された請求総額リスト
-                    amountInTotalInvoice() {
+                    eachTotal() {
                         let invoices = [...this.invoicesInTotalInvoice];
                         let totalBillings = [];
-                        invoices.map(invoice => {
-                            let subTotals = [];
-                            if (invoice.isChecked) {
-                                invoice.invoice_items.map(item => {
-                                    subTotals.push(parseInt(item.count * Math.round(item.price)));
-                                });
-                                const total = subTotals.reduce(function (sum, element) {
-                                    return sum + element;
-                                }, 0);
-                                if (invoice.isTaxExp)
-                                    totalBillings.push(parseInt(total * (1 + invoice.tax / 100)));
-                                else
-                                    totalBillings.push(parseInt(total));
-                            }
-                        });
-                        return totalBillings;
-                    },
-                    // 本体価格
-                    basePriceInTotalInvoice() {
-                        let invoices = [...this.invoicesInTotalInvoice];
                         let basePrices = [];
-                        invoices.map(invoice => {
-                            let subTotals = [];
-                            if (invoice.isChecked) {
-                                invoice.invoice_items.map(item => {
-                                    subTotals.push(parseInt(item.count * Math.round(item.price)));
-                                });
-                                const total = subTotals.reduce(function (sum, element) {
-                                    return sum + element;
-                                }, 0);
-                                if (invoice.isTaxExp)
-                                    basePrices.push(parseInt(total));
-                                else
-                                    basePrices.push(parseInt(total / (1 + invoice.tax / 100)));
-                            }
-                        });
-                        return basePrices;
-                    },
-                    // 消費税額
-                    taxInTotalInvoice() {
-                        let invoices = [...this.invoicesInTotalInvoice];
                         let taxies = [];
                         invoices.map(invoice => {
                             let subTotals = [];
@@ -1672,13 +1630,23 @@
                                 const total = subTotals.reduce(function (sum, element) {
                                     return sum + element;
                                 }, 0);
-                                if (invoice.isTaxExp)
+                                if (invoice.isTaxExp) {
+                                    totalBillings.push(parseInt(total * (1 + invoice.tax / 100)));
+                                    basePrices.push(parseInt(total));
                                     taxies.push(parseInt(total * (1 + invoice.tax / 100) - total));
-                                else
+                                }
+                                else {
+                                    totalBillings.push(parseInt(total));
+                                    basePrices.push(parseInt(total / (1 + invoice.tax / 100)));
                                     taxies.push(parseInt(total - total / (1 + invoice.tax / 100)));
+                                }
                             }
                         });
-                        return taxies;
+                        return {
+                            billings: totalBillings,
+                            basePrices: basePrices,
+                            taxies: taxies 
+                        }
                     },
                     // 得意先選択モーダルの検索機能
                     searchCustomers: function () {


### PR DESCRIPTION
PDF前処理構造体にinovicesを入れるだけで、その下のcustomer情報を読めばよいようにした。
一覧のトータル表示の処理が冗長なのでリファクタリングした。