### PR TITLE
得意先編集画面のロジック・レイアウト大幅変更

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -169,17 +169,19 @@
                             </b-row>
                             <b-row>
                                 <b-col lg>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="お客様区分"
+                                        label-for="customerCategory" label-align="right">
+                                        <b-form-radio-group required v-if="" v-model="customer.customerCategory"
+                                            id="customerCategory" :options="[
+                                            {  text: '法人', value: 'corporation' },
+                                            {  text: '個人', value: 'individual' },
+                                            ]"></b-form-radio-group>
+                                    </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="No.(必須)"
                                         label-for="anyNumber" label-align="right">
                                         <b-form-input v-model="customer.anyNumber" id="anyNumber" size="sm"
                                             :formatter="formatterNumberAll" autocomplete="off">
                                         </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="決算月"
-                                        label-for="closingMonth" label-align="right">
-                                        <b-form-select v-model="customer.closingMonth" :options="closingMonth"
-                                            size="sm">
-                                        </b-form-select>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="得意先名"
                                         label-for="customerName" label-align="right">
@@ -202,12 +204,6 @@
                                             全角カナまたは英数字で入力してください。
                                         </b-form-invalid-feedback>
                                         <b-form-text id="input-live-help">※全角カナ・英数字で入力(例)jマート1</b-form-text>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department" label-align="right">
-                                        <b-form-input v-model="customer.department" id="department" size="sm"
-                                            autocomplete="off">
-                                        </b-form-input>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="郵便番号"
                                         label-for="postNumber" label-align="right">
@@ -239,6 +235,47 @@
                                             autocomplete="off">
                                         </b-form-input>
                                     </b-form-group>
+                                </b-col>
+                                <b-col lg>
+                                    <b-row>
+                                        <b-col lg>
+                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="お気に入り"
+                                                label-for="isFavorite" label-align="right">
+                                                <div v-if="customer.isFavorite===true">
+                                                    <a href="#"
+                                                        style="text-decoration: none;color:#fed11d;padding: 0 7px 0 0;"
+                                                        @click="changeIsFavorite(customer.isFavorite);">
+                                                        <b-icon icon="star-fill"></b-icon>
+                                                    </a>
+                                                </div>
+                                                <div v-else>
+                                                    <a href="#"
+                                                        style="text-decoration: none;color:#000000;padding: 0 7px 0 0;"
+                                                        @click="changeIsFavorite(customer.isFavorite);">
+                                                        <b-icon icon="star"></b-icon>
+                                                    </a>
+                                                </div>
+                                            </b-form-group>
+                                        </b-col>
+                                        <b-col lg>
+                                            <b-form-group label-cols="4" label-cols-lg="4" label-size="sm" label="非表示"
+                                                label-for="isHide" label-align="right">
+                                                <b-form-checkbox v-model="customer.isHide"></b-form-checkbox>
+                                            </b-form-group>
+                                        </b-col>
+                                    </b-row>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="決算月"
+                                        label-for="closingMonth" label-align="right">
+                                        <b-form-select v-model="customer.closingMonth" :options="closingMonth"
+                                            size="sm">
+                                        </b-form-select>
+                                    </b-form-group>
+                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
+                                        label-for="department" label-align="right">
+                                        <b-form-input v-model="customer.department" id="department" size="sm"
+                                            autocomplete="off">
+                                        </b-form-input>
+                                    </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="サイトURL"
                                         label-for="url" label-align="right">
                                         <b-form-input v-model="customer.url" id="url" size="sm" autocomplete="off">
@@ -260,33 +297,6 @@
                                         <b-form-input v-model="customer.manager" id="manager" size="sm"
                                             autocomplete="off">
                                         </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="お客様区分"
-                                        label-for="customerCategory" label-align="right">
-                                        <b-form-radio-group required v-if="" v-model="customer.customerCategory"
-                                            id="customerCategory" :options="[
-                                            {  text: '法人', value: 'corporation' },
-                                            {  text: '個人', value: 'individual' },
-                                            ]"></b-form-radio-group>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="非表示"
-                                        label-for="isHide" label-align="right">
-                                        <b-form-checkbox v-model="customer.isHide"></b-form-checkbox>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="お気に入り"
-                                        label-for="isFavorite" label-align="right">
-                                        <div v-if="customer.isFavorite===true">
-                                            <a href="#" style="text-decoration: none;color:#fed11d;padding: 0 7px 0 0;"
-                                                @click="changeIsFavorite(customer.isFavorite);">
-                                                <b-icon icon="star-fill"></b-icon>
-                                            </a>
-                                        </div>
-                                        <div v-else>
-                                            <a href="#" style="text-decoration: none;color:#000000;padding: 0 7px 0 0;"
-                                                @click="changeIsFavorite(customer.isFavorite);">
-                                                <b-icon icon="star"></b-icon>
-                                            </a>
-                                        </div>
                                     </b-form-group>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
                                         label-for="memo" label-align="right">

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -139,6 +139,35 @@
                         <b-card border-variant="white" class="mb-3 text-center" header="得意先情報"
                             header-border-variant="light">
                             <b-row>
+                                <b-col class="text-right">
+                                    <b-button size="sm" variant="primary" class="mb-3"
+                                        @click="$bvModal.show('customer-invoice-modal')">
+                                        請求書一覧
+                                    </b-button>
+                                    <b-modal size="xl" id="customer-invoice-modal">
+                                        <p>請求書一覧</p>
+                                        <b-table responsive hover small id="invoicetable" label="Table Options"
+                                            borderless :items=customer_invoicesFilter sticky-header
+                                            style="max-height: 500px;" :fields="[
+                                            {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
+                                            {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
+                                            {  key: 'applyDate', label: '日付', thClass: 'th-apply-date text-center', tdClass: 'text-center', sortable: true },
+                                            {  key: 'customerAnyNumber', label: 'No.', thClass: 'th-customer-any-number text-center', tdClass: 'text-center', sortable: true },
+                                            {  key: 'customerName', label: '得意先名', thClass: 'text-center', },
+                                            {  key: 'title', label: '件名', thClass: 'text-center', },
+                                            {  key: 'totalAmount', label: '請求金額', thClass: 'text-center', tdClass: 'text-right' },
+                                            ]" :tbody-tr-class="rowClass">
+                                            <template v-slot:cell(applyDate)="data">
+                                                {{formatDate(data.item.applyDate)}}
+                                            </template>
+                                            <template v-slot:cell(totalAmount)="data">
+                                                {{amountCalculation(data.item)|nf}}
+                                            </template>
+                                        </b-table>
+                                    </b-modal>
+                                </b-col>
+                            </b-row>
+                            <b-row>
                                 <b-col lg>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="No.(必須)"
                                         label-for="anyNumber" label-align="right">
@@ -264,25 +293,6 @@
                                         <b-form-textarea v-model="customer.memo" size="sm" rows="4">
                                         </b-form-textarea>
                                     </b-form-group>
-                                </b-col>
-                                <b-col lg>
-                                    <b-table responsive hover small id="invoicetable" label="Table Options" borderless
-                                        :items=customer_invoicesFilter sticky-header style="max-height: 500px;" :fields="[
-                                            {  key: 'id', thClass: 'd-none', tdClass: 'd-none' },
-                                            {  key: 'applyNumber', label: '請求番号', thClass: 'text-center', tdClass: 'text-center' },
-                                            {  key: 'applyDate', label: '日付', thClass: 'th-apply-date text-center', tdClass: 'text-center', sortable: true },
-                                            {  key: 'customerAnyNumber', label: 'No.', thClass: 'th-customer-any-number text-center', tdClass: 'text-center', sortable: true },
-                                            {  key: 'customerName', label: '得意先名', thClass: 'text-center', },
-                                            {  key: 'title', label: '件名', thClass: 'text-center', },
-                                            {  key: 'totalAmount', label: '請求金額', thClass: 'text-center', tdClass: 'text-right' },
-                                            ]" :tbody-tr-class="rowClass">
-                                        <template v-slot:cell(applyDate)="data">
-                                            {{formatDate(data.item.applyDate)}}
-                                        </template>
-                                        <template v-slot:cell(totalAmount)="data">
-                                            {{amountCalculation(data.item)|nf}}
-                                        </template>
-                                    </b-table>
                                 </b-col>
                             </b-row>
                         </b-card>

--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -264,40 +264,43 @@
                                             </b-form-group>
                                         </b-col>
                                     </b-row>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="決算月"
-                                        label-for="closingMonth" label-align="right">
-                                        <b-form-select v-model="customer.closingMonth" :options="closingMonth"
-                                            size="sm">
-                                        </b-form-select>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
-                                        label-for="department" label-align="right">
-                                        <b-form-input v-model="customer.department" id="department" size="sm"
-                                            autocomplete="off">
-                                        </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="サイトURL"
-                                        label-for="url" label-align="right">
-                                        <b-form-input v-model="customer.url" id="url" size="sm" autocomplete="off">
-                                        </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="email"
-                                        label-for="email" label-align="right">
-                                        <b-form-input v-model="customer.email" id="email" size="sm" autocomplete="off">
-                                        </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="代表者名"
-                                        label-for="representative" label-align="right">
-                                        <b-form-input v-model="customer.representative" id="representative" size="sm"
-                                            autocomplete="off">
-                                        </b-form-input>
-                                    </b-form-group>
-                                    <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
-                                        label-for="manager" label-align="right">
-                                        <b-form-input v-model="customer.manager" id="manager" size="sm"
-                                            autocomplete="off">
-                                        </b-form-input>
-                                    </b-form-group>
+                                    <div v-if="customer.customerCategory=='corporation'">
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="決算月"
+                                            label-for="closingMonth" label-align="right">
+                                            <b-form-select v-model="customer.closingMonth" :options="closingMonth"
+                                                size="sm">
+                                            </b-form-select>
+                                        </b-form-group>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="部署"
+                                            label-for="department" label-align="right">
+                                            <b-form-input v-model="customer.department" id="department" size="sm"
+                                                autocomplete="off">
+                                            </b-form-input>
+                                        </b-form-group>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="サイトURL"
+                                            label-for="url" label-align="right">
+                                            <b-form-input v-model="customer.url" id="url" size="sm" autocomplete="off">
+                                            </b-form-input>
+                                        </b-form-group>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="email"
+                                            label-for="email" label-align="right">
+                                            <b-form-input v-model="customer.email" id="email" size="sm"
+                                                autocomplete="off">
+                                            </b-form-input>
+                                        </b-form-group>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="代表者名"
+                                            label-for="representative" label-align="right">
+                                            <b-form-input v-model="customer.representative" id="representative"
+                                                size="sm" autocomplete="off">
+                                            </b-form-input>
+                                        </b-form-group>
+                                        <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="担当者"
+                                            label-for="manager" label-align="right">
+                                            <b-form-input v-model="customer.manager" id="manager" size="sm"
+                                                autocomplete="off">
+                                            </b-form-input>
+                                        </b-form-group>
+                                    </div>
                                     <b-form-group label-cols="4" label-cols-lg="2" label-size="sm" label="メモ"
                                         label-for="memo" label-align="right">
                                         <b-form-textarea v-model="customer.memo" size="sm" rows="4">


### PR DESCRIPTION
関連Issue：
- 得意先編集画面のロジック・レイアウト大幅変更①（得意先に紐づく請求書一覧はモーダルに移動） #1361
- 得意先編集画面のロジック・レイアウト大幅変更②（フォームの配置を大幅変更） #1362
- 得意先編集画面のロジック・レイアウト大幅変更③（お客様区分で個人が選択されたら一部フォーム非表示） #1363

- 得意先編集画面の請求書一覧をモーダルに変更
- 得意先編集画面入力フォームの配置を大幅に変更。
- 得意先編集画面でお客様区分の「個人」が選ばれたら入力フォームを一部非表示にするようにした