### PR TITLE
ページ読み込み時にSetting.contrastによってページ配色を変えるように。全ページ適用。

### DIFF
--- a/app/templates/head.html
+++ b/app/templates/head.html
@@ -238,6 +238,11 @@
                         }
                     }
                 });
+
+                $(function () {
+                    const contrastValue = 100 + Number(localStorage.getItem('contrast'));
+                    document.querySelector('html').style = 'filter: saturate(' + String(contrastValue) + '%)';
+                });
             </script>
 
 </body>

--- a/app/templates/head_min.html
+++ b/app/templates/head_min.html
@@ -133,6 +133,11 @@
 
                 }
                 setInterval(polling_session, 30000)
+
+                $(function () {
+                    const contrastValue = 100 + Number(localStorage.getItem('contrast'));
+                    document.querySelector('html').style = 'filter: saturate(' + String(contrastValue) + '%)';
+                });
             </script>
 
 </body>

--- a/app/templates/setting.html
+++ b/app/templates/setting.html
@@ -390,7 +390,6 @@
                                 app.title = '更新';
                                 app.message = '保存しました。';
                                 app.$bvModal.show('confirmModal');
-                                self.changeContrast();
                             });
                     },
                     getSetting: async function () {
@@ -414,20 +413,14 @@
                             return value > 0 ? 100 : -100;
                         return value;
                     },
-                    changeContrast() {
-                        const contrastValue = 100 + Number(localStorage.getItem('contrast'));
-                        document.querySelector('body').style = 'filter: saturate(' + String(contrastValue) + '%)';
-                    }
                 },
                 mounted: function () {
                     this.getSetting();
                     this.getLoginUser();
                     if (localStorage.getItem('isHideTabletMode'))
                         this.isHideTabletMode = localStorage.getItem('isHideTabletMode');
-                    if (localStorage.getItem('contrast')) {
+                    if (localStorage.getItem('contrast'))
                         this.contrast = localStorage.getItem('contrast');
-                        this.changeContrast();
-                    }
                     document.querySelector('title').textContent = '各種情報設定';
                 },
                 router,


### PR DESCRIPTION
関連Issue：設定で背景色を変更できるようにする。 #1355

- ページ読み込み時にページ全体のコントラスト（彩度）が変わるようにした。
- 設定ページでは保存ボタンを押下したタイミングで変わるようにしていたが、全ページに反映できないので廃止。