### PR TITLE
合計請求件名入力モーダル作成。合計請求書発行時に合計請求データをDBに保存するようにした。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1288,6 +1288,9 @@
                     formatDate(date) {
                         if (!!date) return moment(date).format("YYYY/MM/DD");
                     },
+                    formatDateHyphen(date) {
+                        if (!!date) return moment(date).format("YYYY-MM-DD");
+                    },
                     //商品個数小数点以下切り捨て
                     formatter_count(value) {
                         return Math.floor(value);
@@ -1483,10 +1486,11 @@
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
                                 self.printPdf('/pdf/' + response.data);
+                                const today = this.formatDateHyphen(Date.now());
                                 totalInvoiceData.applyNumbers = applyNumbers;
                                 totalInvoiceData.customerId = customerId;
                                 // TODO:繋ぎこみ未完了
-                                totalInvoiceData.issueDate = '2022-01-01';
+                                totalInvoiceData.issueDate = today;
                                 totalInvoiceData.title = 'test';
                                 // -----
                                 totalInvoiceData.fileName = response.data;

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -233,7 +233,7 @@
                                         <button v-b-modal.modal-close_visit class="btn btn-secondary m-1"
                                             @click="$bvModal.hide('total-invoice-modal')">閉じる</button>
                                         <button v-b-modal.modal-close_visit class="btn btn-primary m-1"
-                                            @click="totalInvoice">印刷</button>
+                                            @click="totalInvoiceSubmit">確定</button>
                                     </template>
                                 </b-modal>
                             </b-row>
@@ -843,6 +843,21 @@
                     </template>
                 </b-modal>
             </div>
+
+            <!-- 件名入力モーダル -->
+            <div>
+                <b-modal id="title-input-modal" title="件名入力">
+                    <p>合計請求書の件名を入力してください。</p>
+                    <b-input v-model="totalInvoiceTitle"></b-input>
+                    <template #modal-footer>
+                        <button v-b-modal.modal-close_visit class="btn btn-secondary m-1"
+                            @click="$bvModal.hide('title-input-modal')">閉じる</button>
+                        <button v-b-modal.modal-close_visit class="btn btn-primary m-1" @click="totalInvoicePrint">
+                            印刷</button>
+                    </template>
+                </b-modal>
+            </div>
+
         </div>
 
         <script>
@@ -898,6 +913,7 @@
                     searchDayStartInTotalInvoice: '',       //合計請求書専用
                     searchDayEndInTotalInvoice: '',         //合計請求書専用
                     invoicesIndicateCountInTotalInvoice: 0, //合計請求書専用
+                    totalInvoiceTitle: '',                  //合計請求書専用
                     selected: { name: null, id: null },
                     fileId: '', //upload用ID
                     dicFiles: [],
@@ -1412,7 +1428,11 @@
                             //顧客情報も合わせて読む isCustomer=true
                             this.getInvoices(this.searchCustomerWordInTotalInvoice, this.offsetInTotalInvoice, true, true);
                     },
-                    async totalInvoice() {
+                    totalInvoiceSubmit() {
+                        totalInvoiceTitle = '';
+                        this.modalShow(this.invoice, 'title-input-modal');
+                    },
+                    async totalInvoicePrint() {
                         let checkedInvoices = [];
                         let customer = {};
                         let prePdfToalInoices = [];
@@ -1486,13 +1506,11 @@
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
                                 self.printPdf('/pdf/' + response.data);
-                                const today = this.formatDateHyphen(Date.now());
+                                const today = app.formatDateHyphen(Date.now());
                                 totalInvoiceData.applyNumbers = applyNumbers;
                                 totalInvoiceData.customerId = customerId;
-                                // TODO:繋ぎこみ未完了
                                 totalInvoiceData.issueDate = today;
-                                totalInvoiceData.title = 'test';
-                                // -----
+                                totalInvoiceData.title = app.totalInvoiceTitle;
                                 totalInvoiceData.fileName = response.data;
                                 axios.post("/total-invoice", totalInvoiceData)
                                     .then(function (response) {


### PR DESCRIPTION
関連Isssue：合計請求レイアウト決定 #1354

- 合計請求書テーブルのissueDateにはPDFを発行した日付が保存されるようにした。
- 合計請求書入力モーダル作成。合計請求書発行前に件名を入力する形にした。
- ↑で入力された件名を合計請求テーブルのtitleに保存されるようにした。