### PR TITLE
得意先新規登録画面ではデフォルトで「法人」が選択されるようにした。

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -480,6 +480,7 @@
                         self.customers.push({
                             isInsert: true,
                             customerKana: "",
+                            customerCategory: "corporation",
                         });
                         self.customer = self.customers.slice(-1)[0];
                         localStorage.setItem('customer', JSON.stringify(self.customer))


### PR DESCRIPTION
関連Issue：得意先新規登録画面はデフォルトで「法人」にチェックが付くようにする #1389