### PR TITLE
メモ４つ機能の入力欄に文字数制限をかけた。請求書に適用。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -8,6 +8,7 @@ from dateutil import relativedelta
 from sqlalchemy import desc, or_, and_, extract, func
 from flask_login import current_user
 from werkzeug.security import generate_password_hash, check_password_hash
+import unicodedata
 
 
 _LIMIT_NUM = 100
@@ -772,6 +773,10 @@ def invoice_create():
         numberOfAttachments=data.get('numberOfAttachments'),
         invoice_items=newInvoiceItems,
     )
+
+    if get_east_asian_width_count(newInvoice.memo1) > 10 or get_east_asian_width_count(newInvoice.memo2) > 10 or get_east_asian_width_count(newInvoice.memo3) > 10 or get_east_asian_width_count(newInvoice.memo4) > 10:
+        return jsonify({"result": "error", "message": "全角文字は5文字以内、半角文字は10文字以内で入力してください。"}), 406
+
     db.session.add(newInvoice)
     db.session.commit()
     id = newInvoice.id
@@ -825,6 +830,9 @@ def invoice_update(id):
     invoice.tax = data.get('tax')
     invoice.isTaxExp = data.get('isTaxExp')
     invoice.numberOfAttachments = data.get('numberOfAttachments')
+
+    if get_east_asian_width_count(invoice.memo1) > 10 or get_east_asian_width_count(invoice.memo2) > 10 or get_east_asian_width_count(invoice.memo3) > 10 or get_east_asian_width_count(invoice.memo4) > 10:
+        return jsonify({"result": "error", "message": "全角文字は5文字以内、半角文字は10文字以内で入力してください。"}), 406
 
     if data.get('invoice_items'):
         update_list = []
@@ -1332,6 +1340,10 @@ def quotation_create():
         numberOfAttachments=data.get('numberOfAttachments'),
         quotation_items=newQuotationItems,
     )
+
+    if get_east_asian_width_count(newQuotation.memo1) > 10 or get_east_asian_width_count(newQuotation.memo2) > 10 or get_east_asian_width_count(newQuotation.memo3) > 10 or get_east_asian_width_count(newQuotation.memo4) > 10:
+        return jsonify({"result": "error", "message": "全角文字は5文字以内、半角文字は10文字以内で入力してください。"}), 406
+
     db.session.add(newQuotation)
     db.session.commit()
     id = newQuotation.id
@@ -1385,6 +1397,9 @@ def quotation_update(id):
     quotation.tax = data.get('tax')
     quotation.isTaxExp = data.get('isTaxExp')
     quotation.numberOfAttachments = data.get('numberOfAttachments')
+
+    if get_east_asian_width_count(quotation.memo1) > 10 or get_east_asian_width_count(quotation.memo2) > 10 or get_east_asian_width_count(quotation.memo3) > 10 or get_east_asian_width_count(quotation.memo4) > 10:
+        return jsonify({"result": "error", "message": "全角文字は5文字以内、半角文字は10文字以内で入力してください。"}), 406
 
     if data.get('quotation_items'):
         update_list = []
@@ -2047,6 +2062,20 @@ def history_index():
 def login_history_index():
     loginHistories = History.query.order_by(desc(History.id)).limit(_LIMIT_NUM)
     return jsonify(HistorySchema(many=True).dump(loginHistories))
+
+
+# 半角を１文字、全角を２文字として文字数カウントする関数
+def get_east_asian_width_count(text):
+    count = 0
+    if text == None:
+        count = 0
+    else:
+        for c in text:
+            if unicodedata.east_asian_width(c) in 'FWA':
+                count += 2
+            else:
+                count += 1
+    return count
 
 
 if __name__ == '__main__':

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -962,11 +962,9 @@
                         }
                         if (!item.id) {
                             await this.insertInvoice(item);
-                            this.$bvModal.show('confirmModal');
                         }
                         else {
                             await this.updateInvoice(item);
-                            this.$bvModal.show('confirmModal');
                             item.invoice_items.sort(function (a, b) {
                                 return (a.rowNum < b.rowNum) ? -1 : 1;
                             });
@@ -980,11 +978,18 @@
                                 console.log(response);
                                 Vue.set(self.invoice, 'id', response.data.id)
                                 self.invoice.isInsert = false;
+                                self.title = '新規作成';
+                                self.message = '保存しました。';
+                                self.$bvModal.show('confirmModal');
+                            })
+                            .catch(function (error) {
+                                console.log(error.response.data.message);
+                                self.title = 'エラー';
+                                self.message = error.response.data.message;
+                                self.$bvModal.show('confirmModalDanger');
                             });
                         await self.getInvoice(self.invoice);
                         localStorage.setItem('invoice', JSON.stringify(self.invoice));
-                        app.title = '新規作成';
-                        app.message = '保存しました。';
                         self.oldInvoice = { ...self.invoice };
                     },
                     updateInvoice: async function (item) {
@@ -992,14 +997,21 @@
                         await axios.put("/v1/invoice/" + item.id, item)
                             .then(function (response) {
                                 console.log(response);
+                                self.title = '更新';
+                                self.message = '保存しました。';
+                                self.$bvModal.show('confirmModal');
+                            })
+                            .catch(function (error) {
+                                console.log(error.response.data.message);
+                                self.title = 'エラー';
+                                self.message = error.response.data.message;
+                                self.$bvModal.show('confirmModalDanger');
                             });
                         await self.getInvoice(self.invoice);
                         self.invoice.invoice_items.sort(function (a, b) {
                             return (a.rowNum < b.rowNum) ? -1 : 1;
                         });
                         localStorage.setItem('invoice', JSON.stringify(self.invoice));
-                        app.title = '更新';
-                        app.message = '保存しました。';
                         self.oldInvoice = { ...self.invoice };
                     },
                     upsertInvoicePayments: async function (item) {


### PR DESCRIPTION
関連Issue：メモ４つ入力欄には文字数制限をかける #1412

- InvoiceとQuotationのPOST、PUTAPIでメモ４つの中で入力文字数の制限オーバーしたものは406を返すようにした。
- 請求書の新規作成・更新時にメモ４つの中で入力文字数の制限オーバーしたものはエラーモーダルを出すようにした。

見積書フロント側には後に実装する。