### PR TITLE
メモ４つ機能に文字数制限機能のフロント側修正。見積書も適用した。

### DIFF
--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -995,11 +995,12 @@
                     updateInvoice: async function (item) {
                         self = this;
                         await axios.put("/v1/invoice/" + item.id, item)
-                            .then(function (response) {
+                            .then(async function (response) {
                                 console.log(response);
                                 self.title = '更新';
                                 self.message = '保存しました。';
                                 self.$bvModal.show('confirmModal');
+                                await self.getInvoice(self.invoice);
                             })
                             .catch(function (error) {
                                 console.log(error.response.data.message);
@@ -1007,7 +1008,6 @@
                                 self.message = error.response.data.message;
                                 self.$bvModal.show('confirmModalDanger');
                             });
-                        await self.getInvoice(self.invoice);
                         self.invoice.invoice_items.sort(function (a, b) {
                             return (a.rowNum < b.rowNum) ? -1 : 1;
                         });

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -880,11 +880,12 @@
                     updateQuotation: async function (item) {
                         self = this;
                         await axios.put("/v1/quotation/" + item.id, item)
-                            .then(function (response) {
+                            .then(async function (response) {
                                 console.log(response);
                                 self.title = '更新';
                                 self.message = '保存しました。'
                                 self.$bvModal.show('confirmModal');
+                                await self.getQuotation(self.quotation);
                             })
                             .catch(function (error) {
                                 console.log(error.response.data.message);
@@ -892,7 +893,6 @@
                                 self.message = error.response.data.message;
                                 self.$bvModal.show('confirmModalDanger');
                             });
-                        await self.getQuotation(self.quotation);
                         self.quotation.quotation_items.sort(function (a, b) {
                             return (a.rowNum < b.rowNum) ? -1 : 1;
                         });

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -846,11 +846,9 @@
                         }
                         if (!item.id) {
                             await this.insertQuotation(item);
-                            this.$bvModal.show('confirmModal');
                         }
                         else {
                             await this.updateQuotation(item);
-                            this.$bvModal.show('confirmModal');
                             item.quotation_items.sort(function (a, b) {
                                 return (a.rowNum < b.rowNum) ? -1 : 1;
                             });
@@ -864,12 +862,19 @@
                                 console.log(response);
                                 Vue.set(self.quotation, 'id', response.data.id)
                                 self.quotation.isInsert = false;
+                                self.title = '新規作成';
+                                self.message = '保存しました。';
+                                self.$bvModal.show('confirmModal');
+                            })
+                            .catch(function (error) {
+                                console.log(error.response.data.message);
+                                self.title = 'エラー';
+                                self.message = error.response.data.message;
+                                self.$bvModal.show('confirmModalDanger');
                             });
                         await self.getQuotation(self.quotation);
                         localStorage.setItem('quotation', JSON.stringify(self.quotation));
                         //self.countChanged = 0;
-                        app.title = '新規作成';
-                        app.message = '保存しました。';
                         self.oldQuotation = { ...self.quotation };
                     },
                     updateQuotation: async function (item) {
@@ -877,6 +882,15 @@
                         await axios.put("/v1/quotation/" + item.id, item)
                             .then(function (response) {
                                 console.log(response);
+                                self.title = '更新';
+                                self.message = '保存しました。'
+                                self.$bvModal.show('confirmModal');
+                            })
+                            .catch(function (error) {
+                                console.log(error.response.data.message);
+                                self.title = 'エラー';
+                                self.message = error.response.data.message;
+                                self.$bvModal.show('confirmModalDanger');
                             });
                         await self.getQuotation(self.quotation);
                         self.quotation.quotation_items.sort(function (a, b) {
@@ -885,9 +899,6 @@
                         localStorage.setItem('quotation', JSON.stringify(self.quotation));
                         self.oldQuotation = { ...self.quotation };
                         //self.countChanged = 0;
-                        app.title = '更新';
-                        app.message = '保存しました。'
-
                     },
                     copyQuotation: async function (item) {
                         let quotationResource = JSON.stringify(item);


### PR DESCRIPTION
関連Issue：メモ４つ入力欄には文字数制限をかける

バック側での制限を行っているので、フロント入力制御はしない。