### PR TITLE
削除済み合計請求参照機能削除

### DIFF
--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -389,7 +389,7 @@ Vue.component('total-invoice-list', {
                     印刷
                 </b-button>
             </template>
-            <template v-if="!isDeleteView" v-slot:cell(delete)="data">
+            <template v-slot:cell(delete)="data">
                 <b-button variant="primary" @click="deleteTotalInvoice(data.item)">
                     削除
                 </b-button>
@@ -400,7 +400,6 @@ Vue.component('total-invoice-list', {
     props: {
         totalInvoicesIndicateIndex: Array,
         sortByTotalInvoices: String,
-        isDeleteView: Boolean,
         sortDesc: Boolean,
         getTotalInvoiceFile: Function,
         deleteTotalInvoice: Function,

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -191,21 +191,10 @@
                                             <total-invoice-ref-search :totalInvoices="totalInvoices"
                                                 @emit-total-ref-invoices="updateTotalInvoices" />
                                         </b-col>
-                                        <b-col class="text-right">
-                                            <b-button v-if="isDeleteView" size="sm" variant="primary" class="mb-3"
-                                                @click="viewTotalInvoices">
-                                                合計請求参照
-                                            </b-button>
-                                            <b-button v-else size="sm" variant="primary" class="mb-3"
-                                                @click="viewDustTotalInvoices">
-                                                削除済み参照
-                                            </b-button>
-
-                                        </b-col>
                                     </b-row>
                                     <total-invoice-list :total-invoices-indicate-index="totalInvoices"
-                                        :sort-by-total-invoices="sortByInvoices" :is-delete-view="isDeleteView"
-                                        :sort-desc="sortDesc" :get-total-invoice-file="getTotalInvoiceFile"
+                                        :sort-by-total-invoices="sortByInvoices" :sort-desc="sortDesc"
+                                        :get-total-invoice-file="getTotalInvoiceFile"
                                         :delete-total-invoice="deleteTotalInvoice">
                                     </total-invoice-list>
                                 </b-modal>
@@ -949,7 +938,6 @@
                     totalInvoiceTitle: '',                  //合計請求書専用
                     totalInvoicePdfFiles: [],               //合計請求書専用
                     totalInvoicePdfFile: {},                //合計請求書専用
-                    isDeleteView: false,                    //合計請求書専用
                     selected: { name: null, id: null },
                     fileId: '', //upload用ID
                     dicFiles: [],
@@ -1005,15 +993,6 @@
                     getTotalInvoices: async function () {
                         self = this;
                         url = '/v1/total-invoices';
-                        await axios.get(url)
-                            .then((response) => {
-                                console.log(response.data);
-                                self.totalInvoices = response.data;
-                            })
-                    },
-                    getDustTotalInvoices: async function () {
-                        self = this;
-                        url = '/v1/dust-total-invoices';
                         await axios.get(url)
                             .then((response) => {
                                 console.log(response.data);
@@ -1520,14 +1499,6 @@
                     totalInvoiceRefOpen() {
                         this.getTotalInvoices();
                         this.$refs['total-invoice-ref-modal'].show();
-                    },
-                    viewTotalInvoices() {
-                        this.isDeleteView = false;
-                        this.getTotalInvoices();
-                    },
-                    viewDustTotalInvoices() {
-                        this.isDeleteView = true;
-                        this.getDustTotalInvoices();
                     },
                     totalInvoiceSubmit() {
                         totalInvoiceTitle = '';


### PR DESCRIPTION
関連Issue：削除済み合計請求書参照は設定→削除済みページに作成する。 #1419

削除済み合計請求書参照は個別にページを作成するので、invoice.html内からは削除