### PR TITLE
合計請求発行時に合計請求番号を割り振るため、発行のロジックを変更

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1260,7 +1260,9 @@ def total_invoice_create():
     )
     db.session.add(newHistory)
     db.session.commit()
-    return jsonify({"result": "OK", "id": id, "data": data})
+    registerTotalInvoice = TotalInvoice.query.order_by(
+        desc(TotalInvoice.id)).first()
+    return jsonify({"result": "OK", "id": id, "data": TotalInvoiceSchema().dump(registerTotalInvoice)})
 
 
 @app.route('/v1/total-invoice/<id>', methods=['PUT'])
@@ -1271,8 +1273,6 @@ def total_invoice_update(id):
     if not totalInvoice:
         return jsonify({"result": "No Data", "id": id, "data": data})
 
-    totalInvoice.totalInvoiceApplyNumber = data.get(
-        'totalInvoiceApplyNumber')if data.get('totalInvoiceApplyNumber') else None
     totalInvoice.applyNumbers = data.get(
         'applyNumbers')if data.get('applyNumbers') else None
     totalInvoice.customerId = data.get(
@@ -1281,11 +1281,11 @@ def total_invoice_update(id):
         'customerName')if data.get('customerName') else None
     totalInvoice.customerAnyNumber = data.get(
         'customerAnyNumber')if data.get('customerAnyNumber') else None
-    totalInvoice.issueDate = data.get(
-        'issueDate')if data.get('issueDate') else None
+    totalInvoice.issueDate = datetime.strptime(
+        data.get('issueDate'), "%Y-%m-%d")if data.get('issueDate') else None
     totalInvoice.title = data.get('title')if data.get('title') else None
-    totalInvoice.filePath = data.get(
-        'filePath')if data.get('filePath') else None
+    totalInvoice.fileName = data.get(
+        'fileName')if data.get('fileName') else None
 
     newHistory = History(
         userName=current_user.id,

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1574,21 +1574,27 @@
                         const mode = 'invoice';
                         docClass = 'origin';
                         const pdfData = getPdfDataTotalInvoice(mode, prePdfTotalInvoices[0], this.setting, docClass);
+                        const today = app.formatDateHyphen(Date.now());
+                        totalInvoiceData.applyNumbers = applyNumbers;
+                        totalInvoiceData.customerId = customerId;
+                        totalInvoiceData.customerName = prePdfTotalInvoices[0].invoices[0].customerName;
+                        totalInvoiceData.customerAnyNumber = prePdfTotalInvoices[0].invoices[0].customerAnyNumber;
+                        totalInvoiceData.issueDate = today;
+                        totalInvoiceData.title = app.totalInvoiceTitle;
+                        await axios.post("/total-invoice", totalInvoiceData)
+                            .then(function (response) {
+                                console.log(response);
+                                totalInvoiceData.id = response.data.id;
+                            });
                         await axios.post("/pdfmaker", pdfData)
                             .then(function (response) {
+                                console.log(response);
                                 self.printPdf('/pdf/' + response.data);
-                                const today = app.formatDateHyphen(Date.now());
-                                totalInvoiceData.applyNumbers = applyNumbers;
-                                totalInvoiceData.customerId = customerId;
-                                totalInvoiceData.customerName = prePdfTotalInvoices[0].invoices[0].customerName;
-                                totalInvoiceData.customerAnyNumber = prePdfTotalInvoices[0].invoices[0].customerAnyNumber;
-                                totalInvoiceData.issueDate = today;
-                                totalInvoiceData.title = app.totalInvoiceTitle;
                                 totalInvoiceData.fileName = response.data;
-                                axios.post("/total-invoice", totalInvoiceData)
-                                    .then(function (response) {
-                                        console.log(response);
-                                    });
+                            });
+                        await axios.put("/v1/total-invoice/" + totalInvoiceData.id, totalInvoiceData)
+                            .then(function (response) {
+                                console.log(response);
                             });
                     },
                     // ----- 子コンポーネントからの値 -----


### PR DESCRIPTION
関連Issue：合計請求レイアウト決定 #1354

合計請求発行時に合計請求番号を割り振る＋PDFファイル名保存のためには、DB保存(TotalInvoice)→請求番号取得→PDF生成→DB更新(TotalInvoice.fileName)というロジックでいく必要があったので、修正。