### PR TITLE
軽減税率機能のフロント側完成。計算・データ整形ロジックを大幅に修正。

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -713,7 +713,7 @@ def invoice_create():
     newInvoiceItems = []
     defaultReducedTax = db.session.query(
         Setting.defaultReducedTax).filter(Setting.id == 1).one()[0]
-    orthopedicsDefaultReducedTax = defaultReducedTax if defaultReducedTax != '' else None
+    orthopedicsDefaultReducedTax = defaultReducedTax if defaultReducedTax != '' else 8
     if data.get('invoice_items'):
         for item in data.get('invoice_items'):
             if item.get('isDelete'):

--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -162,9 +162,10 @@ Vue.component('invoice-list', {
         //請求金額カラム
         amountCalculation(invoice) {
             if (!invoice.invoice_items.length) return 0;
-            let amount = invoice.invoice_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
-            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100));
-            return amount;
+            let amount = invoice.invoice_items.filter(item => item.isReduced === false).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            let amountReduced = invoice.invoice_items.filter(item => item.isReduced === true).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100) + amountReduced * (1 + invoice.reduced / 100));
+            return amount + amountReduced;
         },
     },
 })

--- a/app/static/component/list-invoice.js
+++ b/app/static/component/list-invoice.js
@@ -225,9 +225,10 @@ Vue.component('invoice-list-payment', {
         //請求金額カラム
         amountCalculation(invoice) {
             if (!invoice.invoice_items.length) return 0;
-            let amount = invoice.invoice_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
-            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100));
-            return amount;
+            let amount = invoice.invoice_items.filter(item => item.isReduced === false).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            let amountReduced = invoice.invoice_items.filter(item => item.isReduced === true).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100) + amountReduced * (1 + invoice.reduced / 100));
+            return amount + amountReduced;
         },
         // 未入金額
         unpaidCalculation(invoice) {
@@ -284,9 +285,10 @@ Vue.component('invoice-list-in-total-invoice', {
         //請求金額カラム
         amountCalculation(invoice) {
             if (!invoice.invoice_items.length) return 0;
-            let amount = invoice.invoice_items.map(item => item.count * Math.round(item.price)).reduce((a, b) => a + b);
-            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100));
-            return amount;
+            let amount = invoice.invoice_items.filter(item => item.isReduced === false).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            let amountReduced = invoice.invoice_items.filter(item => item.isReduced === true).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+            if (invoice.isTaxExp === true) return Math.round(amount * (1 + invoice.tax / 100) + amountReduced * (1 + invoice.reduced / 100));
+            return amount + amountReduced;
         },
     },
 })

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1542,20 +1542,30 @@
                             let totalBillings = [];
                             let basePrices = [];
                             let taxies = [];
+                            let reduceTotalBillings = [];       //税込み(軽減)
+                            let reduceBasePrices = [];          //税抜き(軽減)
+                            let reduceTaxies = [];              //税(軽減)
                             customerId = v;
                             //請求を合算する
                             checkedInvoices[i].forEach(invoice => {
                                 let subTotals = [];
+                                let reduceSubTotals = [];
                                 invoice.invoice_items.forEach(item => {
-                                    subTotals.push(parseInt(item.count * Math.round(item.price)));
+                                    item.isReduced ? reduceSubTotals.push(parseInt(item.count * Math.round(item.price))) : subTotals.push(parseInt(item.count * Math.round(item.price)));
                                 });
                                 const total = subTotals.reduce(function (sum, element) {
+                                    return sum + element;
+                                }, 0);
+                                const reduceTotal = reduceSubTotals.reduce(function (sum, element) {
                                     return sum + element;
                                 }, 0);
                                 if (invoice.isTaxExp) {
                                     totalBillings.push(parseInt(total * (1 + invoice.tax / 100)));
                                     basePrices.push(parseInt(total));
                                     taxies.push(parseInt(total * (1 + invoice.tax / 100) - total));
+                                    reduceTotalBillings.push(parseInt(reduceTotal * (1 + invoice.reduced / 100)));
+                                    reduceBasePrices.push(parseInt(reduceTotal));
+                                    reduceTaxies.push(parseInt(reduceTotal * (1 + invoice.reduced / 100) - reduceTotal));
                                 }
                                 else {
                                     totalBillings.push(parseInt(total));
@@ -1569,11 +1579,12 @@
                                 totalBillings: totalBillings,
                                 basePrices: basePrices,
                                 taxies: taxies,
+                                reduceTotalBillings: reduceTotalBillings,
+                                reduceBasePrices: reduceBasePrices,
+                                reduceTaxies: reduceTaxies,
                                 totalInvoiceApplyNumber: 0
-
                             }
                             prePdfTotalInvoices.push(pt)
-
                         });
                         // ↓最終結果。これをPDF側に渡す
                         const mode = 'invoice';

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1571,6 +1571,9 @@
                                     totalBillings.push(parseInt(total));
                                     basePrices.push(parseInt(total / (1 + invoice.tax / 100)));
                                     taxies.push(parseInt(total - total / (1 + invoice.tax / 100)));
+                                    reduceTotalBillings.push(parseInt(reduceTotal));
+                                    reduceBasePrices.push(parseInt(reduceTotal / (1 + invoice.reduced / 100)));
+                                    reduceTaxies.push(parseInt(reduceTotal - reduceTotal / (1 + invoice.reduced / 100)));
                                 }
                                 applyNumbers = applyNumbers + String(invoice.applyNumber) + ',';
                             });
@@ -1701,9 +1704,8 @@
                     // 逐次、数量＊単価の合計をする
                     sum: function () {
                         if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        let subTotal = this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * Math.round(invoice_item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
-                        if (this.invoice.isTaxExp) return subTotal;
-                        return parseInt(subTotal / (1 + this.invoice.tax / 100));
+                        if (this.invoice.isTaxExp) return this.taxCalculation + this.reduceCalculation;
+                        return parseInt(this.taxCalculation / (1 + this.invoice.tax / 100) + (this.reduceCalculation / (1 + this.invoice.reduced / 100)));
                     },
                     // 入金合計額
                     paymentSum: function () {
@@ -1719,18 +1721,32 @@
                     //消費税総額
                     taxAmount: function () {
                         if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
-                        if (this.invoice.isTaxExp)
-                            return Math.round(this.sum * (this.invoice.tax / 100));
-                        let subTotal = this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * Math.round(invoice_item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
-                        return subTotal - this.sum;
+                        return this.normalTax + this.reducedTax;
                     },
                     //税込み総額
                     priceIncludingTax: function () {
                         if (typeof (this.invoice.invoice_items) == 'undefined') { return 0 } //初期立ち上がりでのエラー抑制
+                        return this.sum + this.taxAmount;
+                    },
+                    // 通常税率適用対象の小計
+                    taxCalculation: function () {
+                        return this.invoice.invoice_items.filter(item => item.isReduced == false).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+                    },
+                    // 軽減税率適用対象の小計
+                    reduceCalculation: function () {
+                        return this.invoice.invoice_items.filter(item => item.isReduced == true).map(item => parseInt(item.count * Math.round(item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
+                    },
+                    // 通常税率適用の消費税
+                    normalTax: function () {
                         if (this.invoice.isTaxExp)
-                            return Math.round(this.sum * (1 + this.invoice.tax / 100));
-                        return this.invoice.invoice_items.map(invoice_item => parseInt(invoice_item.count * Math.round(invoice_item.price))).reduce(function (a, b) { return a + (isNaN(b) ? 0 : b) }, 0);
-                        // return this.sum;
+                            return Math.round(this.taxCalculation * (this.invoice.tax / 100));
+                        return Math.round(this.taxCalculation - (this.taxCalculation / (1 + this.invoice.tax / 100)));
+                    },
+                    // 軽減税率適用の消費税
+                    reducedTax: function () {
+                        if (this.invoice.isTaxExp)
+                            return Math.round(this.reduceCalculation * (this.invoice.reduced / 100));
+                        return Math.round(this.reduceCalculation - (this.reduceCalculation / (1 + this.invoice.reduced / 100)));
                     },
                     invoicesIndicateIndex: function () {
                         let invoices = this.invoices;


### PR DESCRIPTION
関連Issue：軽減税率機能の実装 #1350

- PDF出力の際に必要となる軽減税率適用後の小計・消費税・請求総額を参照できるように計算・データ整形ロジックを大幅に修正
- 請求・未入金請求・合計請求一覧での請求金額計算ロジックを修正した。