### PR TITLE
新規作成時に入力→戻る動作をしても未更新アラートが出ないバグを修正

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -579,7 +579,7 @@
                         return data;
                     },
                     isDiffObject: function () {
-                        if (this.oldCustomer.length == 0 || this.customer.length == 0) return false;
+                        if (this.customer.length == 0) return false;
                         if (JSON.stringify(this.oldCustomer) === JSON.stringify(this.customer)) return false;
                         else return true;
                     },

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -1428,7 +1428,7 @@
                         });
                     }, //-- end upload functions
                     isDiffObject: function () {
-                        if (this.oldInvoice.length == 0 || this.invoice.length == 0) return false;
+                        if (this.invoice.length == 0) return false;
                         if (JSON.stringify(this.oldInvoice) === JSON.stringify(this.invoice)) return false;
                         else return true;
                     },

--- a/app/templates/item.html
+++ b/app/templates/item.html
@@ -648,7 +648,7 @@
                     },
                     //---------変更があったかどうかをチェク。アラート ---------
                     isDiffObject: function () {
-                        if (this.oldItem.length == 0 || this.item.length == 0) return false;
+                        if (this.item.length == 0) return false;
                         if (JSON.stringify(this.oldItem) === JSON.stringify(this.item)) return false;
                         else return true;
                     },

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -1188,7 +1188,7 @@
                         });
                     }, //-- end upload functions
                     isDiffObject: function () {
-                        if (this.oldQuotation.length == 0 || this.quotation.length == 0) return false;
+                        if (this.quotation.length == 0) return false;
                         if (JSON.stringify(this.oldQuotation) === JSON.stringify(this.quotation)) return false;
                         else return true;
                     },


### PR DESCRIPTION
新規作成時にはold○○(oldInvoice等)は取得されずに、old○○.lengthで常に0を返すのが原因だったので、それを修正。